### PR TITLE
added comp-polylines

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -19,15 +19,15 @@ jobs:
 
     - uses: supplypike/setup-bin@v3
       with:
-        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0/cr'
+        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.2/cr'
         name: 'cr'
-        version: '0.7.0'
+        version: '0.7.2'
 
     - uses: supplypike/setup-bin@v3
       with:
-        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0/caps'
+        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.2/caps'
         name: 'caps'
-        version: '0.7.0'
+        version: '0.7.2'
 
     - name: "compiles to js"
       run: >

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ fn fragment_main(vtx_out: VertexOut) -> @location(0) vec4f {
 Curves
 
 ```cirru
-lagopus.comp.curves :refer $ comp-curves comp-polylines
+lagopus.comp.curves :refer $ comp-curves comp-polylines break-mark
 
 comp-curves $ {} (; :topology :line-strip)
   :curves $ []
@@ -119,17 +119,17 @@ It does not require "flatterned" list so is supposed to be a little performant.
 
 ```cirru
 comp-polylines $ {} (; :topology :line-strip)
-  :data $ []
-    [] $ []
+  :writer $ fn $ (write!)
+    write! $ []
       : vertex ([] 0 0 0) width
       : vertex ([] 100 100 0) width
-      : break
+      , break-mark
       : vertex ([] 0 0 10) width
       : vertex ([] 200 0 10) width
       : vertex ([] 200 20 0) width
       : vertex ([] 100 40 0) width
       : vertex ([] 100 20 200) width
-      : break
+      , break-mark
 ```
 
 Spots

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ fn fragment_main(vtx_out: VertexOut) -> @location(0) vec4f {
 Curves
 
 ```cirru
-lagopus.comp.curves :refer $ comp-curves
+lagopus.comp.curves :refer $ comp-curves comp-polylines
 
 comp-curves $ {} (; :topology :line-strip)
   :curves $ []
@@ -110,6 +110,26 @@ comp-curves $ {} (; :topology :line-strip)
               * 0.6 idx
               * r $ sin angle
             :width 2
+```
+
+Another way of defining lines is `comp-polylines` that seperate segments with `:: :break`s.
+It does not require "flatterned" list so is supposed to be a little performant.
+
+> note that `: vertex p` is a short form for `:: :vertex p` since Calcit `0.7.2` .
+
+```cirru
+comp-polylines $ {} (; :topology :line-strip)
+  :data $ []
+    [] $ []
+      : vertex ([] 0 0 0) width
+      : vertex ([] 100 100 0) width
+      : break
+      : vertex ([] 0 0 10) width
+      : vertex ([] 200 0 10) width
+      : vertex ([] 200 20 0) width
+      : vertex ([] 100 40 0) width
+      : vertex ([] 100 20 200) width
+      : break
 ```
 
 Spots

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {}
-  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.1.1)
+  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.1.2)
     :modules $ [] |memof/ |quaternion/
   :entries $ {}
   :ir $ {} (:package |lagopus)
@@ -2940,13 +2940,16 @@
                               |b $ {} (:at 1687103237900) (:by |rJG4IHzWf) (:text |:line-strip) (:type :leaf)
                           |b $ {} (:at 1687101858992) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1687101859543) (:by |rJG4IHzWf) (:text |:data) (:type :leaf)
-                              |b $ {} (:at 1687104173853) (:by |rJG4IHzWf) (:type :expr)
+                              |T $ {} (:at 1687504587992) (:by |rJG4IHzWf) (:text |:writer) (:type :leaf)
+                              |b $ {} (:at 1687504589076) (:by |rJG4IHzWf) (:type :expr)
                                 :data $ {}
-                                  |D $ {} (:at 1687104174326) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                  |D $ {} (:at 1687504589629) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                  |L $ {} (:at 1687504589878) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687504596554) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
                                   |T $ {} (:at 1687104171920) (:by |rJG4IHzWf) (:type :expr)
                                     :data $ {}
-                                      |D $ {} (:at 1687104172602) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                      |D $ {} (:at 1687504600573) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
                                       |T $ {} (:at 1687101859924) (:by |rJG4IHzWf) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1687101860319) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
@@ -2972,10 +2975,7 @@
                                                   |h $ {} (:at 1687103925960) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
                                                   |l $ {} (:at 1687101869600) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
                                               |h $ {} (:at 1687103455191) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |l $ {} (:at 1687101877968) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101882046) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                              |b $ {} (:at 1687101884009) (:by |rJG4IHzWf) (:text |break) (:type :leaf)
+                                          |l $ {} (:at 1687504625134) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
                                           |q $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
                                             :data $ {}
                                               |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
@@ -3031,10 +3031,7 @@
                                                   |h $ {} (:at 1687102809900) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
                                                   |l $ {} (:at 1687103972325) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
                                               |l $ {} (:at 1687103454036) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |t $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |break) (:type :leaf)
+                                          |t $ {} (:at 1687504615483) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
         :ns $ {} (:at 1677433051244) (:by |rJG4IHzWf) (:type :expr)
           :data $ {}
             |T $ {} (:at 1677433051244) (:by |rJG4IHzWf) (:text |ns) (:type :leaf)
@@ -3078,6 +3075,7 @@
                         |T $ {} (:at 1679327350157) (:by |rJG4IHzWf) (:text |comp-curves) (:type :leaf)
                         |b $ {} (:at 1680554541875) (:by |rJG4IHzWf) (:text |comp-axis) (:type :leaf)
                         |h $ {} (:at 1687101908612) (:by |rJG4IHzWf) (:text |comp-polylines) (:type :leaf)
+                        |l $ {} (:at 1687504620478) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
                 |n $ {} (:at 1680200122550) (:by |rJG4IHzWf) (:type :expr)
                   :data $ {}
                     |T $ {} (:at 1680200126860) (:by |rJG4IHzWf) (:text |lagopus.comp.spots) (:type :leaf)
@@ -3525,6 +3523,14 @@
       |lagopus.comp.curves $ {}
         :configs $ {}
         :defs $ {}
+          |break-mark $ {} (:at 1687501310835) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687501314150) (:by |rJG4IHzWf) (:text |def) (:type :leaf)
+              |b $ {} (:at 1687501310835) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
+              |h $ {} (:at 1687501310835) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687501316550) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                  |b $ {} (:at 1687501317696) (:by |rJG4IHzWf) (:text |:break) (:type :leaf)
           |build-curve-points $ {} (:at 1679326965967) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1679326965967) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
@@ -4430,7 +4436,7 @@
                     :data $ {}
                       |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1687100962339) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                          |T $ {} (:at 1687504517753) (:by |rJG4IHzWf) (:text |chunk-writer!) (:type :leaf)
                           |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |either) (:type :leaf)
@@ -4438,10 +4444,17 @@
                                 :data $ {}
                                   |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
                                   |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
-                                  |h $ {} (:at 1687100959501) (:by |rJG4IHzWf) (:text |:data) (:type :leaf)
-                              |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                  |h $ {} (:at 1687504434274) (:by |rJG4IHzWf) (:text |:writer) (:type :leaf)
+                              |h $ {} (:at 1687504438156) (:by |rJG4IHzWf) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                  |T $ {} (:at 1687504439268) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                  |b $ {} (:at 1687504440471) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687504442457) (:by |rJG4IHzWf) (:text |_) (:type :leaf)
+                                  |h $ {} (:at 1687504443153) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687504446727) (:by |rJG4IHzWf) (:text |js/console.warn) (:type :leaf)
+                                      |b $ {} (:at 1687504460241) (:by |rJG4IHzWf) (:text "|\"expected polylines writer") (:type :leaf)
                   |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1687420191668) (:by |rJG4IHzWf) (:text |object-writer) (:type :leaf)
@@ -4528,60 +4541,36 @@
                                                   |b $ {} (:at 1687100850133) (:by |rJG4IHzWf) (:type :expr)
                                                     :data $ {}
                                                       |T $ {} (:at 1687100907030) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
-                                                  |h $ {} (:at 1687100909099) (:by |rJG4IHzWf) (:type :expr)
+                                                  |h $ {} (:at 1687504555722) (:by |rJG4IHzWf) (:type :expr)
                                                     :data $ {}
-                                                      |T $ {} (:at 1687100918235) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
-                                                      |h $ {} (:at 1687100921806) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
-                                                      |l $ {} (:at 1687100922345) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
-                                                      |o $ {} (:at 1687420107924) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                                      |D $ {} (:at 1687504556344) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
+                                                      |L $ {} (:at 1687504556990) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687504558567) (:by |rJG4IHzWf) (:text |list?) (:type :leaf)
+                                                          |b $ {} (:at 1687504558893) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                                      |P $ {} (:at 1687504559780) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687504565401) (:by |rJG4IHzWf) (:text |&doseq) (:type :leaf)
+                                                          |b $ {} (:at 1687504566751) (:by |rJG4IHzWf) (:type :expr)
+                                                            :data $ {}
+                                                              |T $ {} (:at 1687504569148) (:by |rJG4IHzWf) (:text |x) (:type :leaf)
+                                                              |b $ {} (:at 1687504569449) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                                          |h $ {} (:at 1687504572285) (:by |rJG4IHzWf) (:type :expr)
+                                                            :data $ {}
+                                                              |T $ {} (:at 1687504572285) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
+                                                              |b $ {} (:at 1687504572285) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                                              |h $ {} (:at 1687504573983) (:by |rJG4IHzWf) (:text |x) (:type :leaf)
+                                                              |l $ {} (:at 1687504572285) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                                      |T $ {} (:at 1687100909099) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687100918235) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
+                                                          |h $ {} (:at 1687100921806) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                                          |l $ {} (:at 1687100922345) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                                          |o $ {} (:at 1687420107924) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
                                       |d $ {} (:at 1687100965176) (:by |rJG4IHzWf) (:type :expr)
                                         :data $ {}
-                                          |T $ {} (:at 1687100974373) (:by |rJG4IHzWf) (:text |traverse-polylines-data) (:type :leaf)
-                                          |b $ {} (:at 1687100976622) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                                          |T $ {} (:at 1687504538755) (:by |rJG4IHzWf) (:text |chunk-writer!) (:type :leaf)
                                           |h $ {} (:at 1687100978832) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
-          |traverse-polylines-data $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:type :expr)
-            :data $ {}
-              |T $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
-              |b $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:text |traverse-polylines-data) (:type :leaf)
-              |h $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
-                  |b $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
-              |l $ {} (:at 1687100982910) (:by |rJG4IHzWf) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1687100998670) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
-                  |b $ {} (:at 1687100999193) (:by |rJG4IHzWf) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1687101001540) (:by |rJG4IHzWf) (:text |list?) (:type :leaf)
-                      |b $ {} (:at 1687101002201) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
-                  |h $ {} (:at 1687101006274) (:by |rJG4IHzWf) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1687101010299) (:by |rJG4IHzWf) (:text |&doseq) (:type :leaf)
-                      |b $ {} (:at 1687101010788) (:by |rJG4IHzWf) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1687101012054) (:by |rJG4IHzWf) (:text |item) (:type :leaf)
-                          |b $ {} (:at 1687101012694) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
-                      |h $ {} (:at 1687101013833) (:by |rJG4IHzWf) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1687101016140) (:by |rJG4IHzWf) (:text |traverse-polylines-data) (:type :leaf)
-                          |b $ {} (:at 1687101020316) (:by |rJG4IHzWf) (:text |item) (:type :leaf)
-                          |h $ {} (:at 1687101021860) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
-                  |l $ {} (:at 1687101024967) (:by |rJG4IHzWf) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1687101026092) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
-                      |b $ {} (:at 1687101026823) (:by |rJG4IHzWf) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1687101027936) (:by |rJG4IHzWf) (:text |tuple?) (:type :leaf)
-                          |b $ {} (:at 1687101029149) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
-                      |h $ {} (:at 1687101034791) (:by |rJG4IHzWf) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1687101037761) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
-                          |b $ {} (:at 1687101038558) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
-                      |l $ {} (:at 1687101041194) (:by |rJG4IHzWf) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1687101053789) (:by |rJG4IHzWf) (:text |js/console.error) (:type :leaf)
-                          |b $ {} (:at 1687101066152) (:by |rJG4IHzWf) (:text "|\"Unexpected polyline data:") (:type :leaf)
-                          |h $ {} (:at 1687101067727) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
           |wgsl-curves $ {} (:at 1681920827676) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1681920827676) (:by |rJG4IHzWf) (:text |def) (:type :leaf)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -421,14 +421,6 @@
                             :data $ {}
                               |T $ {} (:at 1677604922064) (:by |rJG4IHzWf) (:text |count-recursive) (:type :leaf)
                               |b $ {} (:at 1677604930665) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
-                      |o $ {} (:at 1678902868393) (:by |rJG4IHzWf) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1678902870708) (:by |rJG4IHzWf) (:text |indices) (:type :leaf)
-                          |b $ {} (:at 1678902872142) (:by |rJG4IHzWf) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1678902874224) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
-                              |b $ {} (:at 1678902875989) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
-                              |h $ {} (:at 1678902878554) (:by |rJG4IHzWf) (:text |:indices) (:type :leaf)
                       |q $ {} (:at 1678903542379) (:by |rJG4IHzWf) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1678903544253) (:by |rJG4IHzWf) (:text |buffers) (:type :leaf)
@@ -518,7 +510,6 @@
                                               |Y $ {} (:at 1678905312533) (:by |rJG4IHzWf) (:text |field) (:type :leaf)
                                               |YT $ {} (:at 1686411480293) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
                                               |Z $ {} (:at 1678904674542) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
-                                              |b $ {} (:at 1678904532528) (:by |rJG4IHzWf) (:text |) (:type :leaf)
                                           |Y $ {} (:at 1678904857286) (:by |rJG4IHzWf) (:type :expr)
                                             :data $ {}
                                               |D $ {} (:at 1678905429560) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
@@ -542,11 +533,11 @@
                                               |h $ {} (:at 1686412063414) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
                                                   |D $ {} (:at 1686412065439) (:by |rJG4IHzWf) (:text |eprintln) (:type :leaf)
-                                                  |T $ {} (:at 1678904576817) (:by |rJG4IHzWf) (:text "|\"buffer size guessed correctly") (:type :leaf)
+                                                  |T $ {} (:at 1687406240014) (:by |rJG4IHzWf) (:text "|\"buffer size guessed incorrectly") (:type :leaf)
                                           |b $ {} (:at 1678904453786) (:by |rJG4IHzWf) (:text |buffer) (:type :leaf)
                   |aT $ {} (:at 1678729202699) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
-                      |D $ {} (:at 1687102590086) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
+                      |D $ {} (:at 1687406256089) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
                       |T $ {} (:at 1678905409172) (:by |rJG4IHzWf) (:text |js/console.log) (:type :leaf)
                       |b $ {} (:at 1678729202699) (:by |rJG4IHzWf) (:text |vertices-size) (:type :leaf)
                       |l $ {} (:at 1678903824482) (:by |rJG4IHzWf) (:text |buffers) (:type :leaf)
@@ -578,11 +569,15 @@
                       |r $ {} (:at 1678986343142) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
                       |s $ {} (:at 1678902892989) (:by |rJG4IHzWf) (:type :expr)
                         :data $ {}
-                          |D $ {} (:at 1678902895062) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
-                          |L $ {} (:at 1678902895577) (:by |rJG4IHzWf) (:type :expr)
+                          |D $ {} (:at 1687412252105) (:by |rJG4IHzWf) (:text |if-let) (:type :leaf)
+                          |H $ {} (:at 1687412252768) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1678902897250) (:by |rJG4IHzWf) (:text |some?) (:type :leaf)
-                              |b $ {} (:at 1678902899017) (:by |rJG4IHzWf) (:text |indices) (:type :leaf)
+                              |T $ {} (:at 1687412252768) (:by |rJG4IHzWf) (:text |indices) (:type :leaf)
+                              |b $ {} (:at 1687412252768) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687412252768) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                  |b $ {} (:at 1687412252768) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                                  |h $ {} (:at 1687412252768) (:by |rJG4IHzWf) (:text |:indices) (:type :leaf)
                           |T $ {} (:at 1678902884141) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1678902890487) (:by |rJG4IHzWf) (:text |u32buffer) (:type :leaf)
@@ -623,6 +618,319 @@
                           |T $ {} (:at 1680712947504) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
                           |b $ {} (:at 1680712949087) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
                           |h $ {} (:at 1680712953994) (:by |rJG4IHzWf) (:text |:add-uniform) (:type :leaf)
+          |object-writer $ {} (:at 1687413134159) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687413134159) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1687413134159) (:by |rJG4IHzWf) (:text |object-writer) (:type :leaf)
+              |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+              |l $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                  |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |attrs-list) (:type :leaf)
+                          |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |map) (:type :leaf)
+                              |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                  |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                                  |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |:attrs-list) (:type :leaf)
+                              |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |expand-attr) (:type :leaf)
+                      |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687419202684) (:by |rJG4IHzWf) (:text |writer) (:type :leaf)
+                          |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                              |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                              |h $ {} (:at 1687420338267) (:by |rJG4IHzWf) (:text |:writer) (:type :leaf)
+                      |j $ {} (:at 1687413483549) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687413518058) (:by |rJG4IHzWf) (:text |bundles) (:type :leaf)
+                          |b $ {} (:at 1687420459268) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1687420463443) (:by |rJG4IHzWf) (:text |js-array) (:type :leaf)
+                              |L $ {} (:at 1687420464529) (:by |rJG4IHzWf) (:text |&) (:type :leaf)
+                              |P $ {} (:at 1687421016917) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687421018720) (:by |rJG4IHzWf) (:text |->) (:type :leaf)
+                                  |b $ {} (:at 1687421019176) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687421020059) (:by |rJG4IHzWf) (:text |range) (:type :leaf)
+                                      |b $ {} (:at 1687421022592) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687421022592) (:by |rJG4IHzWf) (:text |count) (:type :leaf)
+                                          |b $ {} (:at 1687421022592) (:by |rJG4IHzWf) (:text |attrs-list) (:type :leaf)
+                                  |h $ {} (:at 1687421023357) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687421024649) (:by |rJG4IHzWf) (:text |map) (:type :leaf)
+                                      |b $ {} (:at 1687421025029) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687421025796) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                          |b $ {} (:at 1687421026106) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687421026357) (:by |rJG4IHzWf) (:text |_) (:type :leaf)
+                                          |h $ {} (:at 1687421027048) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687421029710) (:by |rJG4IHzWf) (:text |js-array) (:type :leaf)
+                      |k $ {} (:at 1687420213019) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687420216927) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
+                          |b $ {} (:at 1687420218244) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687420218767) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
+                              |b $ {} (:at 1687420219015) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                      |kT $ {} (:at 1687420220268) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687420235971) (:by |rJG4IHzWf) (:text |count!) (:type :leaf)
+                          |b $ {} (:at 1687420221446) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687420222215) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                              |b $ {} (:at 1687420222516) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687420243295) (:by |rJG4IHzWf) (:text |x) (:type :leaf)
+                              |h $ {} (:at 1687420226606) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687420230705) (:by |rJG4IHzWf) (:text |swap!) (:type :leaf)
+                                  |b $ {} (:at 1687420232664) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
+                                  |h $ {} (:at 1687420245405) (:by |rJG4IHzWf) (:text |&+) (:type :leaf)
+                                  |l $ {} (:at 1687420246546) (:by |rJG4IHzWf) (:text |x) (:type :leaf)
+                      |l $ {} (:at 1687419367779) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687419369753) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                          |b $ {} (:at 1687419370242) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687419371467) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                              |b $ {} (:at 1687419372157) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687419438930) (:by |rJG4IHzWf) (:text |chunk) (:type :leaf)
+                              |h $ {} (:at 1687419462713) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687419463415) (:by |rJG4IHzWf) (:text |&doseq) (:type :leaf)
+                                  |P $ {} (:at 1687419463415) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687419463415) (:by |rJG4IHzWf) (:text |record) (:type :leaf)
+                                      |b $ {} (:at 1687419463415) (:by |rJG4IHzWf) (:text |chunk) (:type :leaf)
+                                  |T $ {} (:at 1687420254321) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687420259054) (:by |rJG4IHzWf) (:text |count!) (:type :leaf)
+                                      |b $ {} (:at 1687420268927) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                  |Y $ {} (:at 1687419467826) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687419467826) (:by |rJG4IHzWf) (:text |map-indexed) (:type :leaf)
+                                      |b $ {} (:at 1687419467826) (:by |rJG4IHzWf) (:text |attrs-list) (:type :leaf)
+                                      |h $ {} (:at 1687419467826) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687419467826) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                          |b $ {} (:at 1687419467826) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687419467826) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                              |b $ {} (:at 1687419467826) (:by |rJG4IHzWf) (:text |attr) (:type :leaf)
+                                          |e $ {} (:at 1687419482305) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |D $ {} (:at 1687419483551) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                                              |T $ {} (:at 1687419478616) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687419478616) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687419478616) (:by |rJG4IHzWf) (:text |arr) (:type :leaf)
+                                                      |b $ {} (:at 1687419478616) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687419478616) (:by |rJG4IHzWf) (:text |aget) (:type :leaf)
+                                                          |b $ {} (:at 1687419478616) (:by |rJG4IHzWf) (:text |bundles) (:type :leaf)
+                                                          |h $ {} (:at 1687419478616) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                                  |b $ {} (:at 1687420548792) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687420549822) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                                                      |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |do) (:type :leaf)
+                                                          |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:type :expr)
+                                                            :data $ {}
+                                                              |T $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |assert) (:type :leaf)
+                                                              |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text "|\"expected tuple") (:type :leaf)
+                                                              |h $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |tuple?) (:type :leaf)
+                                                                  |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |record) (:type :leaf)
+                                                          |h $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:type :expr)
+                                                            :data $ {}
+                                                              |T $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
+                                                              |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |not=) (:type :leaf)
+                                                                  |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                                  |h $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:type :expr)
+                                                                    :data $ {}
+                                                                      |T $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |nth) (:type :leaf)
+                                                                      |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |record) (:type :leaf)
+                                                                      |h $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                              |h $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |js/console.warn) (:type :leaf)
+                                                                  |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text "|\"expected :vertex tag") (:type :leaf)
+                                                                  |h $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |record) (:type :leaf)
+                                                          |l $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:type :expr)
+                                                            :data $ {}
+                                                              |T $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |nth) (:type :leaf)
+                                                              |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |record) (:type :leaf)
+                                                              |h $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:type :expr)
+                                                                :data $ {}
+                                                                  |T $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |inc) (:type :leaf)
+                                                                  |b $ {} (:at 1687420551776) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                              |b $ {} (:at 1687420554883) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |D $ {} (:at 1687420555362) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
+                                                  |L $ {} (:at 1687420555592) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687420556338) (:by |rJG4IHzWf) (:text |list?) (:type :leaf)
+                                                      |b $ {} (:at 1687420556977) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                                                  |P $ {} (:at 1687420560705) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687420566596) (:by |rJG4IHzWf) (:text |&doseq) (:type :leaf)
+                                                      |b $ {} (:at 1687420567172) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687420567814) (:by |rJG4IHzWf) (:text |d) (:type :leaf)
+                                                          |b $ {} (:at 1687420568695) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                                                      |h $ {} (:at 1687420571061) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687420571061) (:by |rJG4IHzWf) (:text |.!push) (:type :leaf)
+                                                          |b $ {} (:at 1687420571061) (:by |rJG4IHzWf) (:text |arr) (:type :leaf)
+                                                          |h $ {} (:at 1687420572437) (:by |rJG4IHzWf) (:text |d) (:type :leaf)
+                                                  |T $ {} (:at 1687419484315) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687419508698) (:by |rJG4IHzWf) (:text |.!push) (:type :leaf)
+                                                      |b $ {} (:at 1687419509420) (:by |rJG4IHzWf) (:text |arr) (:type :leaf)
+                                                      |h $ {} (:at 1687420554044) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                      |q $ {} (:at 1687419226299) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687419228694) (:by |rJG4IHzWf) (:text |buffers) (:type :leaf)
+                          |b $ {} (:at 1687419229036) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687419230388) (:by |rJG4IHzWf) (:text |do) (:type :leaf)
+                              |b $ {} (:at 1687419232914) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687419234673) (:by |rJG4IHzWf) (:text |writer) (:type :leaf)
+                                  |b $ {} (:at 1687419249120) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                              |h $ {} (:at 1687419312328) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687419313768) (:by |rJG4IHzWf) (:text |js-array) (:type :leaf)
+                                  |L $ {} (:at 1687419669452) (:by |rJG4IHzWf) (:text |&) (:type :leaf)
+                                  |T $ {} (:at 1687419256921) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687419301472) (:by |rJG4IHzWf) (:text |map-indexed) (:type :leaf)
+                                      |b $ {} (:at 1687419304790) (:by |rJG4IHzWf) (:text |attrs-list) (:type :leaf)
+                                      |h $ {} (:at 1687419305051) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687419307140) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                          |b $ {} (:at 1687419307382) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687419307774) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                              |b $ {} (:at 1687419309486) (:by |rJG4IHzWf) (:text |attr) (:type :leaf)
+                                          |h $ {} (:at 1687419317246) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687419317246) (:by |rJG4IHzWf) (:text |newBufferFormatArray) (:type :leaf)
+                                              |b $ {} (:at 1687419323759) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687419323759) (:by |rJG4IHzWf) (:text |buffer-format) (:type :leaf)
+                                                  |b $ {} (:at 1687419323759) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687419323759) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                                      |b $ {} (:at 1687419323759) (:by |rJG4IHzWf) (:text |attr) (:type :leaf)
+                                                      |h $ {} (:at 1687419323759) (:by |rJG4IHzWf) (:text |:format) (:type :leaf)
+                                              |h $ {} (:at 1687419334657) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687419335672) (:by |rJG4IHzWf) (:text |aget) (:type :leaf)
+                                                  |b $ {} (:at 1687419337905) (:by |rJG4IHzWf) (:text |bundles) (:type :leaf)
+                                                  |h $ {} (:at 1687419339899) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                  |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |H $ {} (:at 1687421056997) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
+                      |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |js/console.log) (:type :leaf)
+                      |h $ {} (:at 1687420275547) (:by |rJG4IHzWf) (:text |@*counter) (:type :leaf)
+                      |l $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |buffers) (:type :leaf)
+                  |l $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |createRenderer) (:type :leaf)
+                      |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |inject-shader-snippets) (:type :leaf)
+                          |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                              |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                              |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |:shader) (:type :leaf)
+                      |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |turn-string) (:type :leaf)
+                          |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                              |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                              |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
+                      |l $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |to-js-data) (:type :leaf)
+                          |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |attrs-list) (:type :leaf)
+                      |o $ {} (:at 1687420278212) (:by |rJG4IHzWf) (:text |@*counter) (:type :leaf)
+                      |q $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |buffers) (:type :leaf)
+                      |s $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
+                      |t $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |if-let) (:type :leaf)
+                          |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |indices) (:type :leaf)
+                              |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                  |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                                  |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |:indices) (:type :leaf)
+                          |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |u32buffer) (:type :leaf)
+                              |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                                  |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |*arr) (:type :leaf)
+                                          |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |js-array) (:type :leaf)
+                                      |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                                          |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                              |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |x) (:type :leaf)
+                                              |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |.!push) (:type :leaf)
+                                                  |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |*arr) (:type :leaf)
+                                                  |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |x) (:type :leaf)
+                                  |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |collect-array!) (:type :leaf)
+                                      |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |indices) (:type :leaf)
+                                      |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                                  |l $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |*arr) (:type :leaf)
+                      |u $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                          |b $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                          |h $ {} (:at 1687413136240) (:by |rJG4IHzWf) (:text |:add-uniform) (:type :leaf)
           |wgsl-colors $ {} (:at 1679329122236) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1679329122236) (:by |rJG4IHzWf) (:text |def) (:type :leaf)
@@ -687,6 +995,7 @@
                         |T $ {} (:at 1677604796202) (:by |rJG4IHzWf) (:text |createRenderer) (:type :leaf)
                         |b $ {} (:at 1678902918251) (:by |rJG4IHzWf) (:text |u32buffer) (:type :leaf)
                         |h $ {} (:at 1678903908601) (:by |rJG4IHzWf) (:text |newBufferFormatLength) (:type :leaf)
+                        |l $ {} (:at 1687420293737) (:by |rJG4IHzWf) (:text |newBufferFormatArray) (:type :leaf)
                 |j $ {} (:at 1677524690143) (:by |rJG4IHzWf) (:type :expr)
                   :data $ {}
                     |T $ {} (:at 1678027173099) (:by |rJG4IHzWf) (:text "|\"@triadica/lagopus") (:type :leaf)
@@ -3546,10 +3855,10 @@
               |b $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
               |h $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
                   |b $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
                   |e $ {} (:at 1687102393574) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
                   |h $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                  |l $ {} (:at 1687420123871) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
               |l $ {} (:at 1687101092604) (:by |rJG4IHzWf) (:type :expr)
                 :data $ {}
                   |T $ {} (:at 1687101228978) (:by |rJG4IHzWf) (:text |tag-match) (:type :leaf)
@@ -3720,9 +4029,7 @@
                                                   |h $ {} (:at 1687102133529) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
                                       |h $ {} (:at 1687101494165) (:by |rJG4IHzWf) (:type :expr)
                                         :data $ {}
-                                          |D $ {} (:at 1687101496931) (:by |rJG4IHzWf) (:text |swap!) (:type :leaf)
-                                          |L $ {} (:at 1687101499922) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
-                                          |P $ {} (:at 1687101503322) (:by |rJG4IHzWf) (:text |conj) (:type :leaf)
+                                          |D $ {} (:at 1687420127122) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
                                           |T $ {} (:at 1687101485907) (:by |rJG4IHzWf) (:type :expr)
                                             :data $ {}
                                               |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
@@ -3839,9 +4146,7 @@
                                                   |h $ {} (:at 1687102236811) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
                                       |h $ {} (:at 1687101494165) (:by |rJG4IHzWf) (:type :expr)
                                         :data $ {}
-                                          |D $ {} (:at 1687101496931) (:by |rJG4IHzWf) (:text |swap!) (:type :leaf)
-                                          |L $ {} (:at 1687101499922) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
-                                          |P $ {} (:at 1687101503322) (:by |rJG4IHzWf) (:text |conj) (:type :leaf)
+                                          |D $ {} (:at 1687420129300) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
                                           |T $ {} (:at 1687101485907) (:by |rJG4IHzWf) (:type :expr)
                                             :data $ {}
                                               |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
@@ -4233,7 +4538,7 @@
                                   |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
                   |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |object) (:type :leaf)
+                      |T $ {} (:at 1687420191668) (:by |rJG4IHzWf) (:text |object-writer) (:type :leaf)
                       |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
@@ -4299,60 +4604,53 @@
                                       |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
                           |o $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:data) (:type :leaf)
-                              |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                              |T $ {} (:at 1687420089165) (:by |rJG4IHzWf) (:text |:writer) (:type :leaf)
+                              |b $ {} (:at 1687420089952) (:by |rJG4IHzWf) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1687100797460) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
-                                  |a $ {} (:at 1687100797694) (:by |rJG4IHzWf) (:type :expr)
+                                  |D $ {} (:at 1687420091010) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                  |L $ {} (:at 1687420091785) (:by |rJG4IHzWf) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1687100797831) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1687100805251) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
-                                          |b $ {} (:at 1687100807595) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687100808151) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
-                                              |b $ {} (:at 1687100831784) (:by |rJG4IHzWf) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1687100831901) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
-                                      |X $ {} (:at 1687100854938) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1687100856700) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
-                                          |b $ {} (:at 1687100857956) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687100858461) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
-                                              |b $ {} (:at 1687100859026) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
-                                      |Z $ {} (:at 1687102382873) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1687102385463) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
-                                          |b $ {} (:at 1687102386703) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687102387884) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
-                                              |b $ {} (:at 1687102388784) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                      |b $ {} (:at 1687100837144) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1687100848609) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
-                                          |b $ {} (:at 1687100849160) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687100849487) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
-                                              |b $ {} (:at 1687100850133) (:by |rJG4IHzWf) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1687100907030) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
-                                              |h $ {} (:at 1687100909099) (:by |rJG4IHzWf) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1687100918235) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
-                                                  |b $ {} (:at 1687100920138) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
-                                                  |h $ {} (:at 1687100921806) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
-                                                  |j $ {} (:at 1687102391245) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
-                                                  |l $ {} (:at 1687100922345) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
-                                  |d $ {} (:at 1687100965176) (:by |rJG4IHzWf) (:type :expr)
+                                      |T $ {} (:at 1687420098912) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                  |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1687100974373) (:by |rJG4IHzWf) (:text |traverse-polylines-data) (:type :leaf)
-                                      |b $ {} (:at 1687100976622) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
-                                      |h $ {} (:at 1687100978832) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
-                                  |i $ {} (:at 1687101264259) (:by |rJG4IHzWf) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1687101266921) (:by |rJG4IHzWf) (:text |deref) (:type :leaf)
-                                      |b $ {} (:at 1687101268310) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
+                                      |T $ {} (:at 1687100797460) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                                      |a $ {} (:at 1687100797694) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |X $ {} (:at 1687100854938) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687100856700) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                              |b $ {} (:at 1687100857956) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687100858461) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
+                                                  |b $ {} (:at 1687100859026) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
+                                          |Z $ {} (:at 1687102382873) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687102385463) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
+                                              |b $ {} (:at 1687102386703) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102387884) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
+                                                  |b $ {} (:at 1687102388784) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                          |b $ {} (:at 1687100837144) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687100848609) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                                              |b $ {} (:at 1687100849160) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687100849487) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                                  |b $ {} (:at 1687100850133) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687100907030) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                                  |h $ {} (:at 1687100909099) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687100918235) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
+                                                      |h $ {} (:at 1687100921806) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                                      |j $ {} (:at 1687102391245) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
+                                                      |l $ {} (:at 1687100922345) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                                      |o $ {} (:at 1687420107924) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                      |d $ {} (:at 1687100965176) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687100974373) (:by |rJG4IHzWf) (:text |traverse-polylines-data) (:type :leaf)
+                                          |b $ {} (:at 1687100976622) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                                          |h $ {} (:at 1687100978832) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
           |traverse-polylines-data $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
@@ -4424,7 +4722,8 @@
                     |b $ {} (:at 1679326834952) (:by |rJG4IHzWf) (:text |:refer) (:type :leaf)
                     |h $ {} (:at 1679326835224) (:by |rJG4IHzWf) (:type :expr)
                       :data $ {}
-                        |T $ {} (:at 1679326837785) (:by |rJG4IHzWf) (:text |object) (:type :leaf)
+                        |T $ {} (:at 1687420195113) (:by |rJG4IHzWf) (:text |object) (:type :leaf)
+                        |b $ {} (:at 1687420198469) (:by |rJG4IHzWf) (:text |object-writer) (:type :leaf)
                 |h $ {} (:at 1679326794846) (:by |rJG4IHzWf) (:type :expr)
                   :data $ {}
                     |T $ {} (:at 1679326799714) (:by |rJG4IHzWf) (:text |quaternion.core) (:type :leaf)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {}
-  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.0.14)
+  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.1.0)
     :modules $ [] |memof/ |quaternion/
   :entries $ {}
   :ir $ {} (:package |lagopus)
@@ -1661,13 +1661,17 @@
                               |h $ {} (:at 1681580120822) (:by |rJG4IHzWf) (:type :expr)
                                 :data $ {}
                                   |T $ {} (:at 1681580315550) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                                  |b $ {} (:at 1681580317342) (:by |rJG4IHzWf) (:text |cursor) (:type :leaf)
-                                  |h $ {} (:at 1681580317606) (:by |rJG4IHzWf) (:type :expr)
+                                  |b $ {} (:at 1687279620526) (:by |rJG4IHzWf) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1681580318440) (:by |rJG4IHzWf) (:text |assoc) (:type :leaf)
-                                      |b $ {} (:at 1681580320775) (:by |rJG4IHzWf) (:text |state) (:type :leaf)
-                                      |h $ {} (:at 1681580322735) (:by |rJG4IHzWf) (:text |:pos) (:type :leaf)
-                                      |l $ {} (:at 1681580329039) (:by |rJG4IHzWf) (:text |move) (:type :leaf)
+                                      |D $ {} (:at 1687279803963) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |L $ {} (:at 1687279822275) (:by |rJG4IHzWf) (:text |:state) (:type :leaf)
+                                      |T $ {} (:at 1687279621536) (:by |rJG4IHzWf) (:text |cursor) (:type :leaf)
+                                      |b $ {} (:at 1687279638272) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687279638272) (:by |rJG4IHzWf) (:text |assoc) (:type :leaf)
+                                          |b $ {} (:at 1687279638272) (:by |rJG4IHzWf) (:text |state) (:type :leaf)
+                                          |h $ {} (:at 1687279638272) (:by |rJG4IHzWf) (:text |:pos) (:type :leaf)
+                                          |l $ {} (:at 1687279638272) (:by |rJG4IHzWf) (:text |move) (:type :leaf)
           |comp-mountains $ {} (:at 1677948610137) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1677948610137) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
@@ -2110,8 +2114,11 @@
                           |h $ {} (:at 1680554519996) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1680554519996) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1680554519996) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1680554519996) (:by |rJG4IHzWf) (:text |:axis) (:type :leaf)
+                              |b $ {} (:at 1687279188020) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279189519) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279191145) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279193643) (:by |rJG4IHzWf) (:text |:axis) (:type :leaf)
                   |T $ {} (:at 1677952372486) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1677952372486) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2151,8 +2158,11 @@
                           |h $ {} (:at 1677952372486) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1677952372486) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1677952372486) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1677952372486) (:by |rJG4IHzWf) (:text |:mountains) (:type :leaf)
+                              |b $ {} (:at 1687279197490) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279199093) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279200240) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279202777) (:by |rJG4IHzWf) (:text |:mountains) (:type :leaf)
                   |h $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2192,8 +2202,11 @@
                           |h $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1678810094059) (:by |rJG4IHzWf) (:text |:city) (:type :leaf)
+                              |b $ {} (:at 1687279206391) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279207193) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279208390) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279210110) (:by |rJG4IHzWf) (:text |:city) (:type :leaf)
                   |l $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2233,8 +2246,11 @@
                           |h $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1678986258598) (:by |rJG4IHzWf) (:text |:cube) (:type :leaf)
+                              |b $ {} (:at 1687279212765) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279213921) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279215418) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279219294) (:by |rJG4IHzWf) (:text |:cube) (:type :leaf)
                   |o $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2274,8 +2290,11 @@
                           |h $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1679327554307) (:by |rJG4IHzWf) (:text |:ribbon) (:type :leaf)
+                              |b $ {} (:at 1687279223890) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279224602) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279225837) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279227477) (:by |rJG4IHzWf) (:text |:ribbon) (:type :leaf)
                   |q $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2315,8 +2334,11 @@
                           |h $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1680200460431) (:by |rJG4IHzWf) (:text |:necklace) (:type :leaf)
+                              |b $ {} (:at 1687279232519) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279233349) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279234744) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279236562) (:by |rJG4IHzWf) (:text |:necklace) (:type :leaf)
                   |s $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2356,8 +2378,11 @@
                           |h $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1680703121403) (:by |rJG4IHzWf) (:text |:sphere) (:type :leaf)
+                              |b $ {} (:at 1687279239870) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279240837) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279242202) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279243877) (:by |rJG4IHzWf) (:text |:sphere) (:type :leaf)
                   |t $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2397,8 +2422,11 @@
                           |h $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1677952383571) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1681316264293) (:by |rJG4IHzWf) (:text |:plate) (:type :leaf)
+                              |b $ {} (:at 1687279248111) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279248771) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279249862) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279252144) (:by |rJG4IHzWf) (:text |:plate) (:type :leaf)
                   |u $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2438,8 +2466,11 @@
                           |h $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1681579698238) (:by |rJG4IHzWf) (:text |:control) (:type :leaf)
+                              |b $ {} (:at 1687279254638) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279255274) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279256385) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279258226) (:by |rJG4IHzWf) (:text |:control) (:type :leaf)
                   |v $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2479,8 +2510,11 @@
                           |h $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1681625876663) (:by |rJG4IHzWf) (:text |:stitch) (:type :leaf)
+                              |b $ {} (:at 1687279261551) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279263429) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279264495) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279266095) (:by |rJG4IHzWf) (:text |:stitch) (:type :leaf)
                   |w $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2520,8 +2554,11 @@
                           |h $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1681631588314) (:by |rJG4IHzWf) (:text |:bubbles) (:type :leaf)
+                              |b $ {} (:at 1687279274742) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279275345) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279269799) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279277720) (:by |rJG4IHzWf) (:text |:bubbles) (:type :leaf)
                   |x $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
@@ -2561,8 +2598,11 @@
                           |h $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
-                              |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                              |h $ {} (:at 1687102460867) (:by |rJG4IHzWf) (:text |:triangles) (:type :leaf)
+                              |b $ {} (:at 1687279284207) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687279284788) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                  |T $ {} (:at 1687279285973) (:by |rJG4IHzWf) (:text |tab) (:type :leaf)
+                                  |b $ {} (:at 1687279287847) (:by |rJG4IHzWf) (:text |:triangles) (:type :leaf)
           |comp-triangles-demo $ {} (:at 1687101851610) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1687101851610) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
@@ -7679,7 +7719,6 @@
               |h $ {} (:at 1677932176075) (:by |rJG4IHzWf) (:type :expr)
                 :data $ {}
                   |T $ {} (:at 1677932178985) (:by |rJG4IHzWf) (:text |op) (:type :leaf)
-                  |b $ {} (:at 1677932179715) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
               |j $ {} (:at 1677948512581) (:by |rJG4IHzWf) (:type :expr)
                 :data $ {}
                   |T $ {} (:at 1677948512997) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
@@ -7688,7 +7727,6 @@
                     :data $ {}
                       |T $ {} (:at 1677948736320) (:by |rJG4IHzWf) (:text |js/console.log) (:type :leaf)
                       |b $ {} (:at 1677948520970) (:by |rJG4IHzWf) (:text |op) (:type :leaf)
-                      |h $ {} (:at 1677948521676) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
               |l $ {} (:at 1677948369357) (:by |rJG4IHzWf) (:type :expr)
                 :data $ {}
                   |D $ {} (:at 1677948370065) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
@@ -7701,42 +7739,35 @@
                       |b $ {} (:at 1677948395691) (:by |rJG4IHzWf) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1677948398078) (:by |rJG4IHzWf) (:text |next-store) (:type :leaf)
-                          |b $ {} (:at 1681578435341) (:by |rJG4IHzWf) (:type :expr)
+                          |b $ {} (:at 1687279327926) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1681578436587) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
-                              |L $ {} (:at 1681578437117) (:by |rJG4IHzWf) (:type :expr)
+                              |T $ {} (:at 1687279369850) (:by |rJG4IHzWf) (:text |tag-match) (:type :leaf)
+                              |b $ {} (:at 1687279335187) (:by |rJG4IHzWf) (:text |op) (:type :leaf)
+                              |e $ {} (:at 1687279534360) (:by |rJG4IHzWf) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1681578438692) (:by |rJG4IHzWf) (:text |list?) (:type :leaf)
-                                  |b $ {} (:at 1681578439064) (:by |rJG4IHzWf) (:text |op) (:type :leaf)
-                              |P $ {} (:at 1681578441631) (:by |rJG4IHzWf) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1681578456721) (:by |rJG4IHzWf) (:text |update-states) (:type :leaf)
-                                  |b $ {} (:at 1681578445863) (:by |rJG4IHzWf) (:text |store) (:type :leaf)
-                                  |h $ {} (:at 1681578448908) (:by |rJG4IHzWf) (:text |op) (:type :leaf)
-                                  |l $ {} (:at 1681578450080) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
-                              |T $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |case-default) (:type :leaf)
-                                  |b $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |op) (:type :leaf)
-                                  |h $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:type :expr)
+                                  |T $ {} (:at 1687279535761) (:by |rJG4IHzWf) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |do) (:type :leaf)
-                                      |b $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1677948741580) (:by |rJG4IHzWf) (:text |js/console.warn) (:type :leaf)
-                                          |b $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text "|:unknown op") (:type :leaf)
-                                          |h $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |op) (:type :leaf)
-                                          |l $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
-                                      |h $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |store) (:type :leaf)
-                                  |l $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:type :expr)
+                                      |T $ {} (:at 1687279812167) (:by |rJG4IHzWf) (:text |:state) (:type :leaf)
+                                      |b $ {} (:at 1687279542519) (:by |rJG4IHzWf) (:text |c) (:type :leaf)
+                                      |h $ {} (:at 1687279566213) (:by |rJG4IHzWf) (:text |s) (:type :leaf)
+                                  |b $ {} (:at 1687279567800) (:by |rJG4IHzWf) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                                      |b $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |assoc) (:type :leaf)
-                                          |b $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |store) (:type :leaf)
-                                          |h $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
-                                          |l $ {} (:at 1677948398622) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                                      |T $ {} (:at 1687279571255) (:by |rJG4IHzWf) (:text |update-states) (:type :leaf)
+                                      |b $ {} (:at 1687279572079) (:by |rJG4IHzWf) (:text |store) (:type :leaf)
+                                      |h $ {} (:at 1687279583187) (:by |rJG4IHzWf) (:text |c) (:type :leaf)
+                                      |l $ {} (:at 1687279584245) (:by |rJG4IHzWf) (:text |s) (:type :leaf)
+                              |h $ {} (:at 1687279335579) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687279340485) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687279350971) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
+                                      |b $ {} (:at 1687279354831) (:by |rJG4IHzWf) (:text |t) (:type :leaf)
+                                  |b $ {} (:at 1687279355478) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687279356542) (:by |rJG4IHzWf) (:text |assoc) (:type :leaf)
+                                      |b $ {} (:at 1687279358048) (:by |rJG4IHzWf) (:text |store) (:type :leaf)
+                                      |h $ {} (:at 1687279359018) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
+                                      |l $ {} (:at 1687279360639) (:by |rJG4IHzWf) (:text |t) (:type :leaf)
                   |V $ {} (:at 1677948401036) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1677948406785) (:by |rJG4IHzWf) (:text |if) (:type :leaf)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {}
-  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.0.13)
+  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.0.14)
     :modules $ [] |memof/ |quaternion/
   :entries $ {}
   :ir $ {} (:package |lagopus)
@@ -546,7 +546,7 @@
                                           |b $ {} (:at 1678904453786) (:by |rJG4IHzWf) (:text |buffer) (:type :leaf)
                   |aT $ {} (:at 1678729202699) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
-                      |D $ {} (:at 1678905410557) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
+                      |D $ {} (:at 1687102590086) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
                       |T $ {} (:at 1678905409172) (:by |rJG4IHzWf) (:text |js/console.log) (:type :leaf)
                       |b $ {} (:at 1678729202699) (:by |rJG4IHzWf) (:text |vertices-size) (:type :leaf)
                       |l $ {} (:at 1678903824482) (:by |rJG4IHzWf) (:text |buffers) (:type :leaf)
@@ -1550,6 +1550,12 @@
                               |b $ {} (:at 1681631596596) (:by |rJG4IHzWf) (:type :expr)
                                 :data $ {}
                                   |T $ {} (:at 1681631600307) (:by |rJG4IHzWf) (:text |comp-bubbles-demo) (:type :leaf)
+                          |w $ {} (:at 1687101826656) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687101840934) (:by |rJG4IHzWf) (:text |:triangles) (:type :leaf)
+                              |b $ {} (:at 1687101842904) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687101845532) (:by |rJG4IHzWf) (:text |comp-triangles-demo) (:type :leaf)
           |comp-control-demo $ {} (:at 1681580103913) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1681580103913) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
@@ -2516,6 +2522,170 @@
                               |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
                               |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
                               |h $ {} (:at 1681631588314) (:by |rJG4IHzWf) (:text |:bubbles) (:type :leaf)
+                  |x $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |comp-button) (:type :leaf)
+                      |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                          |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                              |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                  |b $ {} (:at 1687102457765) (:by |rJG4IHzWf) (:text |140) (:type :leaf)
+                                  |h $ {} (:at 1681579673600) (:by |rJG4IHzWf) (:text |220) (:type :leaf)
+                                  |l $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                          |h $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |:color) (:type :leaf)
+                              |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                  |b $ {} (:at 1687102465722) (:by |rJG4IHzWf) (:text |0.1) (:type :leaf)
+                                  |h $ {} (:at 1687102469906) (:by |rJG4IHzWf) (:text |0.6) (:type :leaf)
+                                  |l $ {} (:at 1681631577561) (:by |rJG4IHzWf) (:text |0.8) (:type :leaf)
+                                  |o $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                          |l $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |:size) (:type :leaf)
+                              |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
+                      |h $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                          |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |e) (:type :leaf)
+                              |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
+                          |h $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |d!) (:type :leaf)
+                              |b $ {} (:at 1681579645312) (:by |rJG4IHzWf) (:text |:tab) (:type :leaf)
+                              |h $ {} (:at 1687102460867) (:by |rJG4IHzWf) (:text |:triangles) (:type :leaf)
+          |comp-triangles-demo $ {} (:at 1687101851610) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687101851610) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1687101851610) (:by |rJG4IHzWf) (:text |comp-triangles-demo) (:type :leaf)
+              |h $ {} (:at 1687101851610) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+              |l $ {} (:at 1687103437297) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |D $ {} (:at 1687103442807) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                  |L $ {} (:at 1687103438140) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687103438249) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687103440061) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                          |b $ {} (:at 1687104009275) (:by |rJG4IHzWf) (:text |2) (:type :leaf)
+                  |T $ {} (:at 1687101853524) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687101857427) (:by |rJG4IHzWf) (:text |comp-polylines) (:type :leaf)
+                      |b $ {} (:at 1687101858402) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687101858780) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                          |X $ {} (:at 1687102648971) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1687103862329) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
+                              |T $ {} (:at 1687102654886) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
+                              |b $ {} (:at 1687103237900) (:by |rJG4IHzWf) (:text |:line-strip) (:type :leaf)
+                          |b $ {} (:at 1687101858992) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687101859543) (:by |rJG4IHzWf) (:text |:data) (:type :leaf)
+                              |b $ {} (:at 1687104173853) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687104174326) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                  |T $ {} (:at 1687104171920) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |D $ {} (:at 1687104172602) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                      |T $ {} (:at 1687101859924) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687101860319) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                          |b $ {} (:at 1687101861515) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |D $ {} (:at 1687101866202) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                              |T $ {} (:at 1687101865654) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                              |b $ {} (:at 1687101868673) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101868914) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                  |b $ {} (:at 1687101869230) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |h $ {} (:at 1687101869410) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |l $ {} (:at 1687101869600) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                              |h $ {} (:at 1687103456101) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                          |h $ {} (:at 1687101861515) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |D $ {} (:at 1687101866202) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                              |T $ {} (:at 1687101865654) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                              |b $ {} (:at 1687101868673) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101868914) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                  |b $ {} (:at 1687103924977) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                  |h $ {} (:at 1687103925960) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                  |l $ {} (:at 1687101869600) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                              |h $ {} (:at 1687103455191) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                          |l $ {} (:at 1687101877968) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101882046) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                              |b $ {} (:at 1687101884009) (:by |rJG4IHzWf) (:text |break) (:type :leaf)
+                                          |q $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |l $ {} (:at 1687103646701) (:by |rJG4IHzWf) (:text |10) (:type :leaf)
+                                              |l $ {} (:at 1687103448473) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                          |s $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                  |b $ {} (:at 1687103940578) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
+                                                  |h $ {} (:at 1687103180401) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |l $ {} (:at 1687103648375) (:by |rJG4IHzWf) (:text |10) (:type :leaf)
+                                              |l $ {} (:at 1687103450357) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                          |sT $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                  |b $ {} (:at 1687103941691) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
+                                                  |h $ {} (:at 1687103184461) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
+                                                  |l $ {} (:at 1687103185832) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                              |l $ {} (:at 1687103451080) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                          |sj $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                  |b $ {} (:at 1687103957157) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                  |h $ {} (:at 1687103960028) (:by |rJG4IHzWf) (:text |40) (:type :leaf)
+                                                  |l $ {} (:at 1687103193310) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                              |l $ {} (:at 1687103451801) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                          |sr $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                  |b $ {} (:at 1687103983844) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                  |h $ {} (:at 1687102809900) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
+                                                  |l $ {} (:at 1687103972325) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
+                                              |l $ {} (:at 1687103454036) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                          |t $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |break) (:type :leaf)
         :ns $ {} (:at 1677433051244) (:by |rJG4IHzWf) (:type :expr)
           :data $ {}
             |T $ {} (:at 1677433051244) (:by |rJG4IHzWf) (:text |ns) (:type :leaf)
@@ -2558,6 +2728,7 @@
                       :data $ {}
                         |T $ {} (:at 1679327350157) (:by |rJG4IHzWf) (:text |comp-curves) (:type :leaf)
                         |b $ {} (:at 1680554541875) (:by |rJG4IHzWf) (:text |comp-axis) (:type :leaf)
+                        |h $ {} (:at 1687101908612) (:by |rJG4IHzWf) (:text |comp-polylines) (:type :leaf)
                 |n $ {} (:at 1680200122550) (:by |rJG4IHzWf) (:type :expr)
                   :data $ {}
                     |T $ {} (:at 1680200126860) (:by |rJG4IHzWf) (:text |lagopus.comp.spots) (:type :leaf)
@@ -3329,6 +3500,397 @@
                                           |q $ {} (:at 1686411639096) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
                                           |s $ {} (:at 1686411646245) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
                                           |t $ {} (:at 1686411648546) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+          |build-polyline-points $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
+              |h $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
+                  |b $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                  |e $ {} (:at 1687102393574) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
+                  |h $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+              |l $ {} (:at 1687101092604) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687101228978) (:by |rJG4IHzWf) (:text |tag-match) (:type :leaf)
+                  |b $ {} (:at 1687101231900) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                  |l $ {} (:at 1687101309463) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687101441742) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687101311585) (:by |rJG4IHzWf) (:text |:break) (:type :leaf)
+                      |b $ {} (:at 1687101372031) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687101372267) (:by |rJG4IHzWf) (:text |do) (:type :leaf)
+                          |b $ {} (:at 1687101372724) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687101385631) (:by |rJG4IHzWf) (:text |reset!) (:type :leaf)
+                              |b $ {} (:at 1687101387335) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                              |h $ {} (:at 1687101389968) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
+                          |h $ {} (:at 1687102394946) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687102396227) (:by |rJG4IHzWf) (:text |swap!) (:type :leaf)
+                              |b $ {} (:at 1687102434141) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
+                              |h $ {} (:at 1687102403276) (:by |rJG4IHzWf) (:text |inc) (:type :leaf)
+                  |o $ {} (:at 1687101313694) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687101447495) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687101315291) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                          |b $ {} (:at 1687101451417) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                          |h $ {} (:at 1687101452845) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                      |b $ {} (:at 1687101692885) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |D $ {} (:at 1687101696442) (:by |rJG4IHzWf) (:text |if-let) (:type :leaf)
+                          |L $ {} (:at 1687101696715) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687101697207) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                              |b $ {} (:at 1687101699216) (:by |rJG4IHzWf) (:text |@*prev) (:type :leaf)
+                          |T $ {} (:at 1687101395137) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687101399928) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                              |b $ {} (:at 1687101400721) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |b $ {} (:at 1687101777590) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687101780305) (:by |rJG4IHzWf) (:text |older) (:type :leaf)
+                                      |b $ {} (:at 1687101783168) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687103841121) (:by |rJG4IHzWf) (:text |:older) (:type :leaf)
+                                          |b $ {} (:at 1687101783168) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                  |h $ {} (:at 1687102301758) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687102304274) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                      |b $ {} (:at 1687102305106) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687102305664) (:by |rJG4IHzWf) (:text |:idx) (:type :leaf)
+                                          |b $ {} (:at 1687102307367) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                  |l $ {} (:at 1687102310985) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687102313277) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
+                                      |b $ {} (:at 1687102314774) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687102314384) (:by |rJG4IHzWf) (:text |inc) (:type :leaf)
+                                          |b $ {} (:at 1687102315479) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                  |o $ {} (:at 1687102409707) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687102411195) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                      |b $ {} (:at 1687102427801) (:by |rJG4IHzWf) (:text |@*counter) (:type :leaf)
+                              |h $ {} (:at 1687101409096) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687101413433) (:by |rJG4IHzWf) (:text |reset!) (:type :leaf)
+                                  |b $ {} (:at 1687101415023) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                  |h $ {} (:at 1687101746511) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |D $ {} (:at 1687101749073) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                                      |T $ {} (:at 1687101750479) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687101752598) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                          |b $ {} (:at 1687101756799) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                                      |b $ {} (:at 1687101759138) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687101761976) (:by |rJG4IHzWf) (:text |:older) (:type :leaf)
+                                          |b $ {} (:at 1687101785868) (:by |rJG4IHzWf) (:text |older) (:type :leaf)
+                                      |h $ {} (:at 1687102068190) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687102069422) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                          |b $ {} (:at 1687102071236) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687102075438) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                              |b $ {} (:at 1687102076334) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                      |l $ {} (:at 1687102318547) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687102319457) (:by |rJG4IHzWf) (:text |:idx) (:type :leaf)
+                                          |b $ {} (:at 1687102319796) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687102320754) (:by |rJG4IHzWf) (:text |inc) (:type :leaf)
+                                              |b $ {} (:at 1687102321522) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102322283) (:by |rJG4IHzWf) (:text |:idx) (:type :leaf)
+                                                  |b $ {} (:at 1687102324877) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                              |l $ {} (:at 1687101574238) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687101574867) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
+                                  |L $ {} (:at 1687101575101) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687101575915) (:by |rJG4IHzWf) (:text |some?) (:type :leaf)
+                                      |b $ {} (:at 1687103141235) (:by |rJG4IHzWf) (:text |older) (:type :leaf)
+                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                                      |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                              |b $ {} (:at 1687102022578) (:by |rJG4IHzWf) (:text |older) (:type :leaf)
+                                          |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                              |b $ {} (:at 1687102029667) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102029667) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                                  |b $ {} (:at 1687102029667) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                              |b $ {} (:at 1687102034339) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                                          |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |&v-) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |h $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                          |u $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                              |b $ {} (:at 1687102048921) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102048921) (:by |rJG4IHzWf) (:text |&v-) (:type :leaf)
+                                                  |b $ {} (:at 1687102048921) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |h $ {} (:at 1687102048921) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                          |v $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |b $ {} (:at 1687102088879) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102089727) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                                  |b $ {} (:at 1687102091287) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |w $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                              |b $ {} (:at 1687102093908) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                          |x $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |ratio) (:type :leaf)
+                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102124608) (:by |rJG4IHzWf) (:text |&*) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                                  |h $ {} (:at 1687102127692) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
+                                          |y $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |ratio+1) (:type :leaf)
+                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102131312) (:by |rJG4IHzWf) (:text |&*) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
+                                                  |h $ {} (:at 1687102133529) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
+                                      |h $ {} (:at 1687101494165) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |D $ {} (:at 1687101496931) (:by |rJG4IHzWf) (:text |swap!) (:type :leaf)
+                                          |L $ {} (:at 1687101499922) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
+                                          |P $ {} (:at 1687101503322) (:by |rJG4IHzWf) (:text |conj) (:type :leaf)
+                                          |T $ {} (:at 1687101485907) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687102993673) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |h $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687102996388) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                              |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687103002447) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687103004409) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687103005880) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                              |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687103009404) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                                      |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                              |b $ {} (:at 1687102172009) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102178974) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                                  |b $ {} (:at 1687102179920) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                              |b $ {} (:at 1687102187383) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                                          |u $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687102201419) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                              |b $ {} (:at 1687102206953) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102206953) (:by |rJG4IHzWf) (:text |&v-) (:type :leaf)
+                                                  |b $ {} (:at 1687102206953) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |h $ {} (:at 1687102206953) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                          |v $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |b $ {} (:at 1687102217525) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102219557) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                                  |b $ {} (:at 1687102220154) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |w $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                              |b $ {} (:at 1687102224061) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                          |x $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |ratio) (:type :leaf)
+                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102225863) (:by |rJG4IHzWf) (:text |&*) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                                  |h $ {} (:at 1687102228800) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
+                                          |y $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |ratio+1) (:type :leaf)
+                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687102233469) (:by |rJG4IHzWf) (:text |&*) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
+                                                  |h $ {} (:at 1687102236811) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
+                                      |h $ {} (:at 1687101494165) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |D $ {} (:at 1687101496931) (:by |rJG4IHzWf) (:text |swap!) (:type :leaf)
+                                          |L $ {} (:at 1687101499922) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
+                                          |P $ {} (:at 1687101503322) (:by |rJG4IHzWf) (:text |conj) (:type :leaf)
+                                          |T $ {} (:at 1687101485907) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687102978591) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |h $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687102980110) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687102353677) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                              |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687102981367) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687102355379) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687102983485) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687102356896) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687102986428) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687102358579) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                              |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687102987276) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
+                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
+                                                  |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                          |b $ {} (:at 1687101700919) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687101703398) (:by |rJG4IHzWf) (:text |do) (:type :leaf)
+                              |b $ {} (:at 1687101713617) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687101717471) (:by |rJG4IHzWf) (:text |reset!) (:type :leaf)
+                                  |b $ {} (:at 1687101719035) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                  |h $ {} (:at 1687101719628) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687101719976) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                                      |b $ {} (:at 1687101720237) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687101724425) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                          |b $ {} (:at 1687101730194) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                                      |h $ {} (:at 1687101731338) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687101734565) (:by |rJG4IHzWf) (:text |:older) (:type :leaf)
+                                          |b $ {} (:at 1687101737774) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
+                                      |l $ {} (:at 1687102079673) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687102081501) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                          |b $ {} (:at 1687102083006) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                      |o $ {} (:at 1687102294443) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687102295399) (:by |rJG4IHzWf) (:text |:idx) (:type :leaf)
+                                          |b $ {} (:at 1687102296340) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
           |comp-axis $ {} (:at 1680554319316) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1680554319316) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
@@ -3603,6 +4165,197 @@
                                                   |T $ {} (:at 1679326762625) (:by |rJG4IHzWf) (:text |&/) (:type :leaf)
                                                   |b $ {} (:at 1679326762625) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
                                                   |h $ {} (:at 1679326762625) (:by |rJG4IHzWf) (:text |size) (:type :leaf)
+          |comp-polylines $ {} (:at 1687100723243) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687100723243) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1687100723243) (:by |rJG4IHzWf) (:text |comp-polylines) (:type :leaf)
+              |h $ {} (:at 1687100723243) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687100734784) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+              |l $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                  |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687100962339) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                          |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |either) (:type :leaf)
+                              |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                  |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                                  |h $ {} (:at 1687100959501) (:by |rJG4IHzWf) (:text |:data) (:type :leaf)
+                              |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                  |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |object) (:type :leaf)
+                      |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                          |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:shader) (:type :leaf)
+                              |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |either) (:type :leaf)
+                                  |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                      |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:shader) (:type :leaf)
+                                  |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |wgsl-curves) (:type :leaf)
+                          |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
+                              |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |either) (:type :leaf)
+                                  |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                      |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
+                                  |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:triangle-list) (:type :leaf)
+                          |l $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:attrs-list) (:type :leaf)
+                              |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                  |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687104123848) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687104123075) (:by |rJG4IHzWf) (:text |float32x3) (:type :leaf)
+                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                  |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687104127321) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687104126723) (:by |rJG4IHzWf) (:text |uint32) (:type :leaf)
+                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:brush) (:type :leaf)
+                                  |l $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687104129924) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687104129430) (:by |rJG4IHzWf) (:text |float32x3) (:type :leaf)
+                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:direction) (:type :leaf)
+                                  |o $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687104131832) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687104131231) (:by |rJG4IHzWf) (:text |float32) (:type :leaf)
+                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:curve_ratio) (:type :leaf)
+                                  |q $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687104133873) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687104133320) (:by |rJG4IHzWf) (:text |uint32) (:type :leaf)
+                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:color_index) (:type :leaf)
+                                  |s $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687104136264) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687104135579) (:by |rJG4IHzWf) (:text |float32) (:type :leaf)
+                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                          |o $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:data) (:type :leaf)
+                              |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687100797460) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                                  |a $ {} (:at 1687100797694) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687100797831) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687100805251) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
+                                          |b $ {} (:at 1687100807595) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687100808151) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
+                                              |b $ {} (:at 1687100831784) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687100831901) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                      |X $ {} (:at 1687100854938) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687100856700) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                          |b $ {} (:at 1687100857956) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687100858461) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
+                                              |b $ {} (:at 1687100859026) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
+                                      |Z $ {} (:at 1687102382873) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687102385463) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
+                                          |b $ {} (:at 1687102386703) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687102387884) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
+                                              |b $ {} (:at 1687102388784) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                      |b $ {} (:at 1687100837144) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687100848609) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                                          |b $ {} (:at 1687100849160) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687100849487) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                              |b $ {} (:at 1687100850133) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687100907030) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                              |h $ {} (:at 1687100909099) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687100918235) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
+                                                  |b $ {} (:at 1687100920138) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
+                                                  |h $ {} (:at 1687100921806) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                                  |j $ {} (:at 1687102391245) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
+                                                  |l $ {} (:at 1687100922345) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                  |d $ {} (:at 1687100965176) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687100974373) (:by |rJG4IHzWf) (:text |traverse-polylines-data) (:type :leaf)
+                                      |b $ {} (:at 1687100976622) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                                      |h $ {} (:at 1687100978832) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                                  |i $ {} (:at 1687101264259) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687101266921) (:by |rJG4IHzWf) (:text |deref) (:type :leaf)
+                                      |b $ {} (:at 1687101268310) (:by |rJG4IHzWf) (:text |*vertexes) (:type :leaf)
+          |traverse-polylines-data $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:text |traverse-polylines-data) (:type :leaf)
+              |h $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                  |b $ {} (:at 1687100981132) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+              |l $ {} (:at 1687100982910) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687100998670) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
+                  |b $ {} (:at 1687100999193) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687101001540) (:by |rJG4IHzWf) (:text |list?) (:type :leaf)
+                      |b $ {} (:at 1687101002201) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                  |h $ {} (:at 1687101006274) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687101010299) (:by |rJG4IHzWf) (:text |&doseq) (:type :leaf)
+                      |b $ {} (:at 1687101010788) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687101012054) (:by |rJG4IHzWf) (:text |item) (:type :leaf)
+                          |b $ {} (:at 1687101012694) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                      |h $ {} (:at 1687101013833) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687101016140) (:by |rJG4IHzWf) (:text |traverse-polylines-data) (:type :leaf)
+                          |b $ {} (:at 1687101020316) (:by |rJG4IHzWf) (:text |item) (:type :leaf)
+                          |h $ {} (:at 1687101021860) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                  |l $ {} (:at 1687101024967) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687101026092) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
+                      |b $ {} (:at 1687101026823) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687101027936) (:by |rJG4IHzWf) (:text |tuple?) (:type :leaf)
+                          |b $ {} (:at 1687101029149) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                      |h $ {} (:at 1687101034791) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687101037761) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                          |b $ {} (:at 1687101038558) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
+                      |l $ {} (:at 1687101041194) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687101053789) (:by |rJG4IHzWf) (:text |js/console.error) (:type :leaf)
+                          |b $ {} (:at 1687101066152) (:by |rJG4IHzWf) (:text "|\"Unexpected polyline data:") (:type :leaf)
+                          |h $ {} (:at 1687101067727) (:by |rJG4IHzWf) (:text |data) (:type :leaf)
           |wgsl-curves $ {} (:at 1681920827676) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1681920827676) (:by |rJG4IHzWf) (:text |def) (:type :leaf)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {}
-  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.1.2)
+  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.1.3)
     :modules $ [] |memof/ |quaternion/
   :entries $ {}
   :ir $ {} (:package |lagopus)
@@ -2927,111 +2927,228 @@
                         :data $ {}
                           |T $ {} (:at 1687103440061) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
                           |b $ {} (:at 1687104009275) (:by |rJG4IHzWf) (:text |2) (:type :leaf)
-                  |T $ {} (:at 1687101853524) (:by |rJG4IHzWf) (:type :expr)
+                  |T $ {} (:at 1687599181620) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1687101857427) (:by |rJG4IHzWf) (:text |comp-polylines) (:type :leaf)
-                      |b $ {} (:at 1687101858402) (:by |rJG4IHzWf) (:type :expr)
+                      |D $ {} (:at 1687599182733) (:by |rJG4IHzWf) (:text |group) (:type :leaf)
+                      |L $ {} (:at 1687599185439) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
+                      |T $ {} (:at 1687101853524) (:by |rJG4IHzWf) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1687101858780) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
-                          |X $ {} (:at 1687102648971) (:by |rJG4IHzWf) (:type :expr)
+                          |D $ {} (:at 1687599356183) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
+                          |T $ {} (:at 1687101857427) (:by |rJG4IHzWf) (:text |comp-polylines) (:type :leaf)
+                          |b $ {} (:at 1687101858402) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1687103862329) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
-                              |T $ {} (:at 1687102654886) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
-                              |b $ {} (:at 1687103237900) (:by |rJG4IHzWf) (:text |:line-strip) (:type :leaf)
-                          |b $ {} (:at 1687101858992) (:by |rJG4IHzWf) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1687504587992) (:by |rJG4IHzWf) (:text |:writer) (:type :leaf)
-                              |b $ {} (:at 1687504589076) (:by |rJG4IHzWf) (:type :expr)
+                              |T $ {} (:at 1687101858780) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                              |X $ {} (:at 1687102648971) (:by |rJG4IHzWf) (:type :expr)
                                 :data $ {}
-                                  |D $ {} (:at 1687504589629) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
-                                  |L $ {} (:at 1687504589878) (:by |rJG4IHzWf) (:type :expr)
+                                  |D $ {} (:at 1687103862329) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
+                                  |T $ {} (:at 1687102654886) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
+                                  |b $ {} (:at 1687103237900) (:by |rJG4IHzWf) (:text |:line-strip) (:type :leaf)
+                              |b $ {} (:at 1687101858992) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687504587992) (:by |rJG4IHzWf) (:text |:writer) (:type :leaf)
+                                  |b $ {} (:at 1687504589076) (:by |rJG4IHzWf) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1687504596554) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
-                                  |T $ {} (:at 1687104171920) (:by |rJG4IHzWf) (:type :expr)
-                                    :data $ {}
-                                      |D $ {} (:at 1687504600573) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
-                                      |T $ {} (:at 1687101859924) (:by |rJG4IHzWf) (:type :expr)
+                                      |D $ {} (:at 1687504589629) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                      |L $ {} (:at 1687504589878) (:by |rJG4IHzWf) (:type :expr)
                                         :data $ {}
-                                          |T $ {} (:at 1687101860319) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
-                                          |b $ {} (:at 1687101861515) (:by |rJG4IHzWf) (:type :expr)
+                                          |T $ {} (:at 1687504596554) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                      |T $ {} (:at 1687104171920) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |D $ {} (:at 1687504600573) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                          |T $ {} (:at 1687101859924) (:by |rJG4IHzWf) (:type :expr)
                                             :data $ {}
-                                              |D $ {} (:at 1687101866202) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                              |T $ {} (:at 1687101865654) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
-                                              |b $ {} (:at 1687101868673) (:by |rJG4IHzWf) (:type :expr)
+                                              |T $ {} (:at 1687101860319) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                              |b $ {} (:at 1687101861515) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
-                                                  |T $ {} (:at 1687101868914) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
-                                                  |b $ {} (:at 1687101869230) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                                  |h $ {} (:at 1687101869410) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                                  |l $ {} (:at 1687101869600) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                              |h $ {} (:at 1687103456101) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |h $ {} (:at 1687101861515) (:by |rJG4IHzWf) (:type :expr)
+                                                  |D $ {} (:at 1687101866202) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |T $ {} (:at 1687101865654) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |b $ {} (:at 1687101868673) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101868914) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687101869230) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |h $ {} (:at 1687101869410) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |l $ {} (:at 1687101869600) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |h $ {} (:at 1687103456101) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                              |h $ {} (:at 1687101861515) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |D $ {} (:at 1687101866202) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |T $ {} (:at 1687101865654) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |b $ {} (:at 1687101868673) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101868914) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103924977) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                      |h $ {} (:at 1687103925960) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                      |l $ {} (:at 1687101869600) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |h $ {} (:at 1687103455191) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                              |l $ {} (:at 1687504625134) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
+                                              |q $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |l $ {} (:at 1687103646701) (:by |rJG4IHzWf) (:text |10) (:type :leaf)
+                                                  |l $ {} (:at 1687103448473) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                              |s $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103940578) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
+                                                      |h $ {} (:at 1687103180401) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |l $ {} (:at 1687103648375) (:by |rJG4IHzWf) (:text |10) (:type :leaf)
+                                                  |l $ {} (:at 1687103450357) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                              |sT $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103941691) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
+                                                      |h $ {} (:at 1687103184461) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
+                                                      |l $ {} (:at 1687103185832) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |l $ {} (:at 1687103451080) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                              |sj $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103957157) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                      |h $ {} (:at 1687103960028) (:by |rJG4IHzWf) (:text |40) (:type :leaf)
+                                                      |l $ {} (:at 1687103193310) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |l $ {} (:at 1687103451801) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                              |sr $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103983844) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                      |h $ {} (:at 1687102809900) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
+                                                      |l $ {} (:at 1687103972325) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
+                                                  |l $ {} (:at 1687103454036) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                              |t $ {} (:at 1687504615483) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
+                      |b $ {} (:at 1687101853524) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687599192925) (:by |rJG4IHzWf) (:text |comp-polylines-marked) (:type :leaf)
+                          |b $ {} (:at 1687101858402) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687101858780) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                              |X $ {} (:at 1687102648971) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1687103862329) (:by |rJG4IHzWf) (:text |;) (:type :leaf)
+                                  |T $ {} (:at 1687102654886) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
+                                  |b $ {} (:at 1687103237900) (:by |rJG4IHzWf) (:text |:line-strip) (:type :leaf)
+                              |b $ {} (:at 1687101858992) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687504587992) (:by |rJG4IHzWf) (:text |:writer) (:type :leaf)
+                                  |b $ {} (:at 1687504589076) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |D $ {} (:at 1687504589629) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                      |L $ {} (:at 1687504589878) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687504596554) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                      |T $ {} (:at 1687104171920) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |D $ {} (:at 1687504600573) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                          |T $ {} (:at 1687101859924) (:by |rJG4IHzWf) (:type :expr)
                                             :data $ {}
-                                              |D $ {} (:at 1687101866202) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                              |T $ {} (:at 1687101865654) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
-                                              |b $ {} (:at 1687101868673) (:by |rJG4IHzWf) (:type :expr)
+                                              |T $ {} (:at 1687101860319) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                              |b $ {} (:at 1687101861515) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
-                                                  |T $ {} (:at 1687101868914) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
-                                                  |b $ {} (:at 1687103924977) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
-                                                  |h $ {} (:at 1687103925960) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
-                                                  |l $ {} (:at 1687101869600) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                              |h $ {} (:at 1687103455191) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |l $ {} (:at 1687504625134) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
-                                          |q $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
-                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                  |D $ {} (:at 1687101866202) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |T $ {} (:at 1687101865654) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |b $ {} (:at 1687101868673) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101868914) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687101869230) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |h $ {} (:at 1687101869410) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |l $ {} (:at 1687101869600) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |h $ {} (:at 1687103456101) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                                  |l $ {} (:at 1687599363199) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                              |h $ {} (:at 1687101861515) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
-                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
-                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                                  |l $ {} (:at 1687103646701) (:by |rJG4IHzWf) (:text |10) (:type :leaf)
-                                              |l $ {} (:at 1687103448473) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |s $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
-                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                  |D $ {} (:at 1687101866202) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |T $ {} (:at 1687101865654) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |b $ {} (:at 1687101868673) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101868914) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103924977) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                      |h $ {} (:at 1687103925960) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                      |l $ {} (:at 1687101869600) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |h $ {} (:at 1687103455191) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                                  |l $ {} (:at 1687599364135) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                              |l $ {} (:at 1687504625134) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
+                                              |q $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
-                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
-                                                  |b $ {} (:at 1687103940578) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
-                                                  |h $ {} (:at 1687103180401) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                                  |l $ {} (:at 1687103648375) (:by |rJG4IHzWf) (:text |10) (:type :leaf)
-                                              |l $ {} (:at 1687103450357) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |sT $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
-                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |l $ {} (:at 1687103646701) (:by |rJG4IHzWf) (:text |10) (:type :leaf)
+                                                  |l $ {} (:at 1687103448473) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                                  |o $ {} (:at 1687599218559) (:by |rJG4IHzWf) (:text |2) (:type :leaf)
+                                              |s $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
-                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
-                                                  |b $ {} (:at 1687103941691) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
-                                                  |h $ {} (:at 1687103184461) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
-                                                  |l $ {} (:at 1687103185832) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                              |l $ {} (:at 1687103451080) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |sj $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
-                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103940578) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
+                                                      |h $ {} (:at 1687103180401) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                      |l $ {} (:at 1687103648375) (:by |rJG4IHzWf) (:text |10) (:type :leaf)
+                                                  |l $ {} (:at 1687103450357) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                                  |o $ {} (:at 1687599219385) (:by |rJG4IHzWf) (:text |2) (:type :leaf)
+                                              |sT $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
-                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
-                                                  |b $ {} (:at 1687103957157) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
-                                                  |h $ {} (:at 1687103960028) (:by |rJG4IHzWf) (:text |40) (:type :leaf)
-                                                  |l $ {} (:at 1687103193310) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
-                                              |l $ {} (:at 1687103451801) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |sr $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                              |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
-                                              |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103941691) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
+                                                      |h $ {} (:at 1687103184461) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
+                                                      |l $ {} (:at 1687103185832) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |l $ {} (:at 1687103451080) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                                  |o $ {} (:at 1687599220162) (:by |rJG4IHzWf) (:text |2) (:type :leaf)
+                                              |sj $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
-                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
-                                                  |b $ {} (:at 1687103983844) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
-                                                  |h $ {} (:at 1687102809900) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
-                                                  |l $ {} (:at 1687103972325) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
-                                              |l $ {} (:at 1687103454036) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |t $ {} (:at 1687504615483) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103957157) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                      |h $ {} (:at 1687103960028) (:by |rJG4IHzWf) (:text |40) (:type :leaf)
+                                                      |l $ {} (:at 1687103193310) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |l $ {} (:at 1687103451801) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                                  |o $ {} (:at 1687599220879) (:by |rJG4IHzWf) (:text |2) (:type :leaf)
+                                              |sr $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                                  |b $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687101894614) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1687103983844) (:by |rJG4IHzWf) (:text |100) (:type :leaf)
+                                                      |h $ {} (:at 1687102809900) (:by |rJG4IHzWf) (:text |20) (:type :leaf)
+                                                      |l $ {} (:at 1687103972325) (:by |rJG4IHzWf) (:text |200) (:type :leaf)
+                                                  |l $ {} (:at 1687103454036) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                                  |o $ {} (:at 1687599221946) (:by |rJG4IHzWf) (:text |2) (:type :leaf)
+                                              |t $ {} (:at 1687504615483) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
         :ns $ {} (:at 1677433051244) (:by |rJG4IHzWf) (:type :expr)
           :data $ {}
             |T $ {} (:at 1677433051244) (:by |rJG4IHzWf) (:text |ns) (:type :leaf)
@@ -3075,6 +3192,7 @@
                         |T $ {} (:at 1679327350157) (:by |rJG4IHzWf) (:text |comp-curves) (:type :leaf)
                         |b $ {} (:at 1680554541875) (:by |rJG4IHzWf) (:text |comp-axis) (:type :leaf)
                         |h $ {} (:at 1687101908612) (:by |rJG4IHzWf) (:text |comp-polylines) (:type :leaf)
+                        |j $ {} (:at 1687599198680) (:by |rJG4IHzWf) (:text |comp-polylines-marked) (:type :leaf)
                         |l $ {} (:at 1687504620478) (:by |rJG4IHzWf) (:text |break-mark) (:type :leaf)
                 |n $ {} (:at 1680200122550) (:by |rJG4IHzWf) (:type :expr)
                   :data $ {}
@@ -4148,6 +4266,334 @@
                                         :data $ {}
                                           |T $ {} (:at 1687102081501) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
                                           |b $ {} (:at 1687102083006) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+          |build-polyline-points-marked $ {} (:at 1687599018338) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687599018338) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1687599134790) (:by |rJG4IHzWf) (:text |build-polyline-points-marked) (:type :leaf)
+              |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+              |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |tag-match) (:type :leaf)
+                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:break) (:type :leaf)
+                      |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |do) (:type :leaf)
+                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |reset!) (:type :leaf)
+                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                              |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
+                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                          |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                          |l $ {} (:at 1687599036422) (:by |rJG4IHzWf) (:text |mark) (:type :leaf)
+                      |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |if-let) (:type :leaf)
+                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |@*prev) (:type :leaf)
+                          |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |older) (:type :leaf)
+                                      |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:older) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                              |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |reset!) (:type :leaf)
+                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                                      |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                                      |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:older) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |older) (:type :leaf)
+                                      |j $ {} (:at 1687599040589) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599041392) (:by |rJG4IHzWf) (:text |:mark) (:type :leaf)
+                                          |b $ {} (:at 1687599042063) (:by |rJG4IHzWf) (:text |mark) (:type :leaf)
+                                      |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                              |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
+                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |some?) (:type :leaf)
+                                      |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |older) (:type :leaf)
+                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                                      |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |older) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |e $ {} (:at 1687599048413) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599051942) (:by |rJG4IHzWf) (:text |prev-mark) (:type :leaf)
+                                              |b $ {} (:at 1687599052950) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599055494) (:by |rJG4IHzWf) (:text |:mark) (:type :leaf)
+                                                  |b $ {} (:at 1687599056327) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                                          |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |&v-) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                          |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |&v-) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                          |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |s $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                      |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599060773) (:by |rJG4IHzWf) (:text |prev-mark) (:type :leaf)
+                                              |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599063471) (:by |rJG4IHzWf) (:text |mark) (:type :leaf)
+                                              |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599065876) (:by |rJG4IHzWf) (:text |prev-mark) (:type :leaf)
+                                              |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599068477) (:by |rJG4IHzWf) (:text |mark) (:type :leaf)
+                                              |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599070606) (:by |rJG4IHzWf) (:text |mark) (:type :leaf)
+                                              |s $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599072653) (:by |rJG4IHzWf) (:text |prev-mark) (:type :leaf)
+                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                                      |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |X $ {} (:at 1687599087681) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599087681) (:by |rJG4IHzWf) (:text |prev-mark) (:type :leaf)
+                                              |b $ {} (:at 1687599087681) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599087681) (:by |rJG4IHzWf) (:text |:mark) (:type :leaf)
+                                                  |b $ {} (:at 1687599087681) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                                          |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |&v-) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                          |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
+                                          |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
+                                      |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599076443) (:by |rJG4IHzWf) (:text |prev-mark) (:type :leaf)
+                                              |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599093683) (:by |rJG4IHzWf) (:text |mark) (:type :leaf)
+                                              |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599096335) (:by |rJG4IHzWf) (:text |prev-mark) (:type :leaf)
+                                              |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599098231) (:by |rJG4IHzWf) (:text |mark) (:type :leaf)
+                                              |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599100222) (:by |rJG4IHzWf) (:text |mark) (:type :leaf)
+                                              |s $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |::) (:type :leaf)
+                                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:vertex) (:type :leaf)
+                                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
+                                                  |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
+                                                  |o $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
+                                                  |q $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
+                                                  |s $ {} (:at 1687599102117) (:by |rJG4IHzWf) (:text |prev-mark) (:type :leaf)
+                          |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |do) (:type :leaf)
+                              |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |reset!) (:type :leaf)
+                                  |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                  |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                                      |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |position) (:type :leaf)
+                                      |h $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:older) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
+                                      |j $ {} (:at 1687599104285) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599106217) (:by |rJG4IHzWf) (:text |:mark) (:type :leaf)
+                                          |b $ {} (:at 1687599106683) (:by |rJG4IHzWf) (:text |mark) (:type :leaf)
+                                      |l $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                          |b $ {} (:at 1687599021483) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
           |comp-axis $ {} (:at 1680554319316) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1680554319316) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
@@ -4571,6 +5017,160 @@
                                         :data $ {}
                                           |T $ {} (:at 1687504538755) (:by |rJG4IHzWf) (:text |chunk-writer!) (:type :leaf)
                                           |h $ {} (:at 1687100978832) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+          |comp-polylines-marked $ {} (:at 1687598969592) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687598969592) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1687598969592) (:by |rJG4IHzWf) (:text |comp-polylines-marked) (:type :leaf)
+              |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+              |l $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                  |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |chunk-writer!) (:type :leaf)
+                          |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |either) (:type :leaf)
+                              |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                  |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                                  |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:writer) (:type :leaf)
+                              |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                  |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |_) (:type :leaf)
+                                  |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |js/console.warn) (:type :leaf)
+                                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text "|\"expected polylines writer") (:type :leaf)
+                  |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |object-writer) (:type :leaf)
+                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |{}) (:type :leaf)
+                          |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:shader) (:type :leaf)
+                              |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |either) (:type :leaf)
+                                  |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                                      |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:shader) (:type :leaf)
+                                  |h $ {} (:at 1687598984169) (:by |rJG4IHzWf) (:text |wgsl-polylines-marked) (:type :leaf)
+                          |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
+                              |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |either) (:type :leaf)
+                                  |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
+                                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
+                                      |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
+                                  |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:triangle-list) (:type :leaf)
+                          |l $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:attrs-list) (:type :leaf)
+                              |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |[]) (:type :leaf)
+                                  |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |float32x3) (:type :leaf)
+                                      |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:position) (:type :leaf)
+                                  |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |uint32) (:type :leaf)
+                                      |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:brush) (:type :leaf)
+                                  |l $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |float32x3) (:type :leaf)
+                                      |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:direction) (:type :leaf)
+                                  |o $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |float32) (:type :leaf)
+                                      |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
+                                  |q $ {} (:at 1687598996210) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598996583) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
+                                      |b $ {} (:at 1687598998733) (:by |rJG4IHzWf) (:text |float32) (:type :leaf)
+                                      |h $ {} (:at 1687598999754) (:by |rJG4IHzWf) (:text |:mark) (:type :leaf)
+                          |o $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |:writer) (:type :leaf)
+                              |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                  |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                  |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |let) (:type :leaf)
+                                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                              |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
+                                                  |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
+                                          |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
+                                              |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |fn) (:type :leaf)
+                                                  |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                                  |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
+                                                      |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |list?) (:type :leaf)
+                                                          |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                                      |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |&doseq) (:type :leaf)
+                                                          |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                                            :data $ {}
+                                                              |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |x) (:type :leaf)
+                                                              |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                                          |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                                            :data $ {}
+                                                              |T $ {} (:at 1687599125403) (:by |rJG4IHzWf) (:text |build-polyline-points-marked) (:type :leaf)
+                                                              |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                                              |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |x) (:type :leaf)
+                                                              |l $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                                      |l $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1687599138440) (:by |rJG4IHzWf) (:text |build-polyline-points-marked) (:type :leaf)
+                                                          |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
+                                                          |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
+                                                          |l $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
+                                      |h $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |chunk-writer!) (:type :leaf)
+                                          |b $ {} (:at 1687598972394) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
           |wgsl-curves $ {} (:at 1681920827676) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1681920827676) (:by |rJG4IHzWf) (:text |def) (:type :leaf)
@@ -4587,6 +5187,14 @@
                 :data $ {}
                   |T $ {} (:at 1687422868641) (:by |rJG4IHzWf) (:text |inline-shader) (:type :leaf)
                   |b $ {} (:at 1687422871892) (:by |rJG4IHzWf) (:text "|\"polylines") (:type :leaf)
+          |wgsl-polylines-marked $ {} (:at 1687598984515) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687598984515) (:by |rJG4IHzWf) (:text |def) (:type :leaf)
+              |b $ {} (:at 1687598984515) (:by |rJG4IHzWf) (:text |wgsl-polylines-marked) (:type :leaf)
+              |h $ {} (:at 1687598986082) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687598986082) (:by |rJG4IHzWf) (:text |inline-shader) (:type :leaf)
+                  |b $ {} (:at 1687598991532) (:by |rJG4IHzWf) (:text "|\"polylines-marked") (:type :leaf)
         :ns $ {} (:at 1679326745678) (:by |rJG4IHzWf) (:type :expr)
           :data $ {}
             |T $ {} (:at 1679326745678) (:by |rJG4IHzWf) (:text |ns) (:type :leaf)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,6 +1,6 @@
 
 {}
-  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.1.0)
+  :configs $ {} (:compact-output? true) (:extension |.cljs) (:init-fn |lagopus.main/main!) (:output |src) (:port 6001) (:reload-fn |lagopus.main/reload!) (:storage-key |calcit.cirru) (:version |0.1.1)
     :modules $ [] |memof/ |quaternion/
   :entries $ {}
   :ir $ {} (:package |lagopus)
@@ -3855,8 +3855,7 @@
               |b $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
               |h $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:type :expr)
                 :data $ {}
-                  |b $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
-                  |e $ {} (:at 1687102393574) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
+                  |b $ {} (:at 1687422793976) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
                   |h $ {} (:at 1687101090407) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
                   |l $ {} (:at 1687420123871) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
               |l $ {} (:at 1687101092604) (:by |rJG4IHzWf) (:type :expr)
@@ -3876,11 +3875,6 @@
                               |T $ {} (:at 1687101385631) (:by |rJG4IHzWf) (:text |reset!) (:type :leaf)
                               |b $ {} (:at 1687101387335) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
                               |h $ {} (:at 1687101389968) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
-                          |h $ {} (:at 1687102394946) (:by |rJG4IHzWf) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1687102396227) (:by |rJG4IHzWf) (:text |swap!) (:type :leaf)
-                              |b $ {} (:at 1687102434141) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
-                              |h $ {} (:at 1687102403276) (:by |rJG4IHzWf) (:text |inc) (:type :leaf)
                   |o $ {} (:at 1687101313694) (:by |rJG4IHzWf) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1687101447495) (:by |rJG4IHzWf) (:type :expr)
@@ -3907,24 +3901,6 @@
                                         :data $ {}
                                           |T $ {} (:at 1687103841121) (:by |rJG4IHzWf) (:text |:older) (:type :leaf)
                                           |b $ {} (:at 1687101783168) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
-                                  |h $ {} (:at 1687102301758) (:by |rJG4IHzWf) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1687102304274) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
-                                      |b $ {} (:at 1687102305106) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1687102305664) (:by |rJG4IHzWf) (:text |:idx) (:type :leaf)
-                                          |b $ {} (:at 1687102307367) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
-                                  |l $ {} (:at 1687102310985) (:by |rJG4IHzWf) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1687102313277) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
-                                      |b $ {} (:at 1687102314774) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1687102314384) (:by |rJG4IHzWf) (:text |inc) (:type :leaf)
-                                          |b $ {} (:at 1687102315479) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
-                                  |o $ {} (:at 1687102409707) (:by |rJG4IHzWf) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1687102411195) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                      |b $ {} (:at 1687102427801) (:by |rJG4IHzWf) (:text |@*counter) (:type :leaf)
                               |h $ {} (:at 1687101409096) (:by |rJG4IHzWf) (:type :expr)
                                 :data $ {}
                                   |T $ {} (:at 1687101413433) (:by |rJG4IHzWf) (:text |reset!) (:type :leaf)
@@ -3947,16 +3923,6 @@
                                             :data $ {}
                                               |T $ {} (:at 1687102075438) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
                                               |b $ {} (:at 1687102076334) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
-                                      |l $ {} (:at 1687102318547) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1687102319457) (:by |rJG4IHzWf) (:text |:idx) (:type :leaf)
-                                          |b $ {} (:at 1687102319796) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687102320754) (:by |rJG4IHzWf) (:text |inc) (:type :leaf)
-                                              |b $ {} (:at 1687102321522) (:by |rJG4IHzWf) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1687102322283) (:by |rJG4IHzWf) (:text |:idx) (:type :leaf)
-                                                  |b $ {} (:at 1687102324877) (:by |rJG4IHzWf) (:text |prev) (:type :leaf)
                               |l $ {} (:at 1687101574238) (:by |rJG4IHzWf) (:type :expr)
                                 :data $ {}
                                   |D $ {} (:at 1687101574867) (:by |rJG4IHzWf) (:text |if) (:type :leaf)
@@ -4011,22 +3977,6 @@
                                             :data $ {}
                                               |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
                                               |b $ {} (:at 1687102093908) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |x $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |ratio) (:type :leaf)
-                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1687102124608) (:by |rJG4IHzWf) (:text |&*) (:type :leaf)
-                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
-                                                  |h $ {} (:at 1687102127692) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
-                                          |y $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |ratio+1) (:type :leaf)
-                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1687102131312) (:by |rJG4IHzWf) (:text |&*) (:type :leaf)
-                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
-                                                  |h $ {} (:at 1687102133529) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
                                       |h $ {} (:at 1687101494165) (:by |rJG4IHzWf) (:type :expr)
                                         :data $ {}
                                           |D $ {} (:at 1687420127122) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
@@ -4040,8 +3990,6 @@
                                                   |h $ {} (:at 1687102993673) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
                                                   |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
                                               |h $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4050,8 +3998,6 @@
                                                   |h $ {} (:at 1687102996388) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
                                                   |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
                                               |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4060,8 +4006,6 @@
                                                   |h $ {} (:at 1687103002447) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
                                                   |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
                                               |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4070,8 +4014,6 @@
                                                   |h $ {} (:at 1687103004409) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
                                                   |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
                                               |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4080,8 +4022,6 @@
                                                   |h $ {} (:at 1687103005880) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
                                                   |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction2) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
                                               |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4090,8 +4030,6 @@
                                                   |h $ {} (:at 1687103009404) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
                                                   |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
                                   |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                     :data $ {}
@@ -4128,22 +4066,6 @@
                                             :data $ {}
                                               |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
                                               |b $ {} (:at 1687102224061) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                          |x $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |ratio) (:type :leaf)
-                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1687102225863) (:by |rJG4IHzWf) (:text |&*) (:type :leaf)
-                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
-                                                  |h $ {} (:at 1687102228800) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
-                                          |y $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |ratio+1) (:type :leaf)
-                                              |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1687102233469) (:by |rJG4IHzWf) (:text |&*) (:type :leaf)
-                                                  |b $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
-                                                  |h $ {} (:at 1687102236811) (:by |rJG4IHzWf) (:text |0.001) (:type :leaf)
                                       |h $ {} (:at 1687101494165) (:by |rJG4IHzWf) (:type :expr)
                                         :data $ {}
                                           |D $ {} (:at 1687420129300) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
@@ -4157,8 +4079,6 @@
                                                   |h $ {} (:at 1687102978591) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
                                                   |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
                                               |h $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4167,8 +4087,6 @@
                                                   |h $ {} (:at 1687102980110) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
                                                   |o $ {} (:at 1687102353677) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
                                               |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4177,8 +4095,6 @@
                                                   |h $ {} (:at 1687102981367) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
                                                   |o $ {} (:at 1687102355379) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
                                               |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4187,8 +4103,6 @@
                                                   |h $ {} (:at 1687102983485) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
                                                   |o $ {} (:at 1687102356896) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
                                               |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4197,8 +4111,6 @@
                                                   |h $ {} (:at 1687102986428) (:by |rJG4IHzWf) (:text |q2) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
                                                   |o $ {} (:at 1687102358579) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx+1) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |q-width) (:type :leaf)
                                               |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:type :expr)
                                                 :data $ {}
@@ -4207,8 +4119,6 @@
                                                   |h $ {} (:at 1687102987276) (:by |rJG4IHzWf) (:text |q) (:type :leaf)
                                                   |l $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |1) (:type :leaf)
                                                   |o $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |direction) (:type :leaf)
-                                                  |q $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |curve-ratio) (:type :leaf)
-                                                  |s $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |idx) (:type :leaf)
                                                   |t $ {} (:at 1687101482643) (:by |rJG4IHzWf) (:text |p-width) (:type :leaf)
                           |b $ {} (:at 1687101700919) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
@@ -4232,10 +4142,6 @@
                                         :data $ {}
                                           |T $ {} (:at 1687102081501) (:by |rJG4IHzWf) (:text |:width) (:type :leaf)
                                           |b $ {} (:at 1687102083006) (:by |rJG4IHzWf) (:text |width) (:type :leaf)
-                                      |o $ {} (:at 1687102294443) (:by |rJG4IHzWf) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1687102295399) (:by |rJG4IHzWf) (:text |:idx) (:type :leaf)
-                                          |b $ {} (:at 1687102296340) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
           |comp-axis $ {} (:at 1680554319316) (:by |rJG4IHzWf) (:type :expr)
             :data $ {}
               |T $ {} (:at 1680554319316) (:by |rJG4IHzWf) (:text |defn) (:type :leaf)
@@ -4553,7 +4459,7 @@
                                       |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |&map:get) (:type :leaf)
                                       |b $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |options) (:type :leaf)
                                       |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:shader) (:type :leaf)
-                                  |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |wgsl-curves) (:type :leaf)
+                                  |h $ {} (:at 1687422850391) (:by |rJG4IHzWf) (:text |wgsl-polylines) (:type :leaf)
                           |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:topology) (:type :leaf)
@@ -4587,16 +4493,6 @@
                                       |T $ {} (:at 1687104129924) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
                                       |b $ {} (:at 1687104129430) (:by |rJG4IHzWf) (:text |float32x3) (:type :leaf)
                                       |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:direction) (:type :leaf)
-                                  |o $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1687104131832) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                      |b $ {} (:at 1687104131231) (:by |rJG4IHzWf) (:text |float32) (:type :leaf)
-                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:curve_ratio) (:type :leaf)
-                                  |q $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1687104133873) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
-                                      |b $ {} (:at 1687104133320) (:by |rJG4IHzWf) (:text |uint32) (:type :leaf)
-                                      |h $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:text |:color_index) (:type :leaf)
                                   |s $ {} (:at 1687100736437) (:by |rJG4IHzWf) (:type :expr)
                                     :data $ {}
                                       |T $ {} (:at 1687104136264) (:by |rJG4IHzWf) (:text |:) (:type :leaf)
@@ -4623,13 +4519,6 @@
                                                 :data $ {}
                                                   |T $ {} (:at 1687100858461) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
                                                   |b $ {} (:at 1687100859026) (:by |rJG4IHzWf) (:text |nil) (:type :leaf)
-                                          |Z $ {} (:at 1687102382873) (:by |rJG4IHzWf) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1687102385463) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
-                                              |b $ {} (:at 1687102386703) (:by |rJG4IHzWf) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1687102387884) (:by |rJG4IHzWf) (:text |atom) (:type :leaf)
-                                                  |b $ {} (:at 1687102388784) (:by |rJG4IHzWf) (:text |0) (:type :leaf)
                                           |b $ {} (:at 1687100837144) (:by |rJG4IHzWf) (:type :expr)
                                             :data $ {}
                                               |T $ {} (:at 1687100848609) (:by |rJG4IHzWf) (:text |collect!) (:type :leaf)
@@ -4643,7 +4532,6 @@
                                                     :data $ {}
                                                       |T $ {} (:at 1687100918235) (:by |rJG4IHzWf) (:text |build-polyline-points) (:type :leaf)
                                                       |h $ {} (:at 1687100921806) (:by |rJG4IHzWf) (:text |*prev) (:type :leaf)
-                                                      |j $ {} (:at 1687102391245) (:by |rJG4IHzWf) (:text |*counter) (:type :leaf)
                                                       |l $ {} (:at 1687100922345) (:by |rJG4IHzWf) (:text |p) (:type :leaf)
                                                       |o $ {} (:at 1687420107924) (:by |rJG4IHzWf) (:text |write!) (:type :leaf)
                                       |d $ {} (:at 1687100965176) (:by |rJG4IHzWf) (:type :expr)
@@ -4702,6 +4590,14 @@
                 :data $ {}
                   |T $ {} (:at 1681920831329) (:by |rJG4IHzWf) (:text |inline-shader) (:type :leaf)
                   |b $ {} (:at 1681920833424) (:by |rJG4IHzWf) (:text "|\"curves") (:type :leaf)
+          |wgsl-polylines $ {} (:at 1687422858502) (:by |rJG4IHzWf) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1687422858502) (:by |rJG4IHzWf) (:text |def) (:type :leaf)
+              |b $ {} (:at 1687422858502) (:by |rJG4IHzWf) (:text |wgsl-polylines) (:type :leaf)
+              |h $ {} (:at 1687422868641) (:by |rJG4IHzWf) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1687422868641) (:by |rJG4IHzWf) (:text |inline-shader) (:type :leaf)
+                  |b $ {} (:at 1687422871892) (:by |rJG4IHzWf) (:text "|\"polylines") (:type :leaf)
         :ns $ {} (:at 1679326745678) (:by |rJG4IHzWf) (:type :expr)
           :data $ {}
             |T $ {} (:at 1679326745678) (:by |rJG4IHzWf) (:text |ns) (:type :leaf)

--- a/compact.cirru
+++ b/compact.cirru
@@ -1,6 +1,6 @@
 
 {} (:package |lagopus)
-  :configs $ {} (:init-fn |lagopus.main/main!) (:reload-fn |lagopus.main/reload!) (:version |0.0.14)
+  :configs $ {} (:init-fn |lagopus.main/main!) (:reload-fn |lagopus.main/reload!) (:version |0.1.0)
     :modules $ [] |memof/ |quaternion/
   :entries $ {}
   :files $ {}
@@ -232,7 +232,7 @@
                     :position $ :pos state
                     :color $ [] 0.6 0.6 1.0 1.0
                   fn (move d!)
-                    d! cursor $ assoc state :pos move
+                    d! $ : :state cursor (assoc state :pos move)
         |comp-mountains $ quote
           defn comp-mountains () $ object
             {} (:shader mountains-wgsl)
@@ -296,73 +296,85 @@
                 :position $ [] 0 260 0
                 :color $ [] 0.5 0.5 0.9 1
                 :size 20
-              fn (e d!) (d! :tab :axis)
+              fn (e d!)
+                d! $ : tab :axis
             comp-button
               {}
                 :position $ [] 40 260 0
                 :color $ [] 0.9 0.4 0.5 1
                 :size 20
-              fn (e d!) (d! :tab :mountains)
+              fn (e d!)
+                d! $ : tab :mountains
             comp-button
               {}
                 :position $ [] 80 260 0
                 :color $ [] 0.8 0.9 0.2 1
                 :size 20
-              fn (e d!) (d! :tab :city)
+              fn (e d!)
+                d! $ : tab :city
             comp-button
               {}
                 :position $ [] 120 260 0
                 :color $ [] 0.3 0.9 0.2 1
                 :size 20
-              fn (e d!) (d! :tab :cube)
+              fn (e d!)
+                d! $ : tab :cube
             comp-button
               {}
                 :position $ [] 160 260 0
                 :color $ [] 0.8 0.0 0.9 1
                 :size 20
-              fn (e d!) (d! :tab :ribbon)
+              fn (e d!)
+                d! $ : tab :ribbon
             comp-button
               {}
                 :position $ [] 200 260 0
                 :color $ [] 0.2 0.9 0.6 1
                 :size 20
-              fn (e d!) (d! :tab :necklace)
+              fn (e d!)
+                d! $ : tab :necklace
             comp-button
               {}
                 :position $ [] 240 260 0
                 :color $ [] 0.2 0.9 0.6 1
                 :size 20
-              fn (e d!) (d! :tab :sphere)
+              fn (e d!)
+                d! $ : tab :sphere
             comp-button
               {}
                 :position $ [] 280 260 0
                 :color $ [] 0.9 0.4 0.6 1
                 :size 20
-              fn (e d!) (d! :tab :plate)
+              fn (e d!)
+                d! $ : tab :plate
             comp-button
               {}
                 :position $ [] 20 220 0
                 :color $ [] 0.7 0.8 0.9 1
                 :size 20
-              fn (e d!) (d! :tab :control)
+              fn (e d!)
+                d! $ : tab :control
             comp-button
               {}
                 :position $ [] 60 220 0
                 :color $ [] 0.9 0.7 0.6 1
                 :size 20
-              fn (e d!) (d! :tab :stitch)
+              fn (e d!)
+                d! $ : tab :stitch
             comp-button
               {}
                 :position $ [] 100 220 0
                 :color $ [] 0.9 0.3 0.8 1
                 :size 20
-              fn (e d!) (d! :tab :bubbles)
+              fn (e d!)
+                d! $ : tab :bubbles
             comp-button
               {}
                 :position $ [] 140 220 0
                 :color $ [] 0.1 0.6 0.8 1
                 :size 20
-              fn (e d!) (d! :tab :triangles)
+              fn (e d!)
+                d! $ : tab :triangles
         |comp-triangles-demo $ quote
           defn comp-triangles-demo () $ let
               width 2
@@ -990,14 +1002,14 @@
         |canvas $ quote
           def canvas $ js/document.querySelector "\"canvas"
         |dispatch! $ quote
-          defn dispatch! (op data)
-            if dev? $ js/console.log op data
+          defn dispatch! (op)
+            if dev? $ js/console.log op
             let
                 store @*store
-                next-store $ if (list? op) (update-states store op data)
-                  case-default op
-                    do (js/console.warn ":unknown op" op data) store
-                    :tab $ assoc store :tab data
+                next-store $ tag-match op
+                    :state c s
+                    update-states store c s
+                  (:tab t) (assoc store :tab t)
               if (not= next-store store) (reset! *store next-store)
         |main! $ quote
           defn main! () (hint-fn async)

--- a/package.cirru
+++ b/package.cirru
@@ -2,4 +2,4 @@
 {}
   :dependencies $ {}
     |calcit-lang/memof |main
-    |calcit-lang/quaternion |main
+    |calcit-lang/quaternion |0.0.6

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "@calcit/procs": "^0.7.2",
     "@calcit/std": "^0.0.2",
-    "@triadica/lagopus": "^0.0.15",
+    "@triadica/lagopus": "^0.0.16-a1",
     "@triadica/touch-control": "^0.0.3",
     "ismobilejs": "^1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "dependencies": {
     "@calcit/procs": "^0.7.2",
     "@calcit/std": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.0.13",
+  "version": "0.0.14",
   "dependencies": {
-    "@calcit/procs": "^0.7.0",
+    "@calcit/procs": "^0.7.2",
     "@calcit/std": "^0.0.2",
-    "@triadica/lagopus": "^0.0.14",
+    "@triadica/lagopus": "^0.0.15",
     "@triadica/touch-control": "^0.0.3",
     "ismobilejs": "^1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.14",
+  "version": "0.1.0",
   "dependencies": {
     "@calcit/procs": "^0.7.2",
     "@calcit/std": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": {
     "@calcit/procs": "^0.7.2",
     "@calcit/std": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": {
     "@calcit/procs": "^0.7.2",
     "@calcit/std": "^0.0.2",

--- a/shaders/polylines-marked.wgsl
+++ b/shaders/polylines-marked.wgsl
@@ -1,0 +1,71 @@
+struct UBO {
+  cone_back_scale: f32,
+  viewport_ratio: f32,
+  look_distance: f32,
+  scale: f32,
+  forward: vec3f,
+  // direction up overhead, better unit vector
+  upward: vec3f,
+  rightward: vec3f,
+  camera_position: vec3f,
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms: UBO;
+
+{{perspective}}
+
+{{colors}}
+
+// main
+
+struct VertexOut {
+  @builtin(position) position: vec4f,
+  @location(0) original: vec3f,
+  @location(1) color: vec3f,
+  @location(2) mark: f32,
+};
+
+@vertex
+fn vertex_main(
+  @location(0) position: vec3f,
+  @location(1) brush: u32,
+  @location(2) direction: vec3f,
+  @location(3) width: f32,
+  @location(4) mark: f32,
+) -> VertexOut {
+  var output: VertexOut;
+
+  var p1 = position;
+
+  var next = cross(direction, uniforms.forward);
+  if (length(next) < 0.0001) {
+    // if parallel, use leftward
+    next = -next;
+  }
+  let brush_direction = normalize(next);
+  if (brush == 1) {
+    p1 += brush_direction * width * 0.5;
+  } else {
+    p1 -= brush_direction * width * 0.5;
+  }
+
+  let p = transform_perspective(p1.xyz).point_position;
+  let scale: f32 = 0.002;
+  output.position = vec4(p[0]*scale, p[1]*scale, p[2]*scale, 1.0);
+  output.original = position;
+  output.color = hsl(0.14, 1.0, 0.2);
+  output.mark = mark;
+
+  return output;
+}
+
+const middle: f32 = 50.0;
+const limit: f32 = 48.0;
+
+@fragment
+fn fragment_main(vtx_out: VertexOut) -> @location(0) vec4f {
+  // return vec4f(vtx_out.color, 1.0);
+  let color = hsl(fract(0.14 + vtx_out.mark * 0.2), 1.0, 0.4);
+  return vec4f(color, 1.0);
+}

--- a/shaders/polylines.wgsl
+++ b/shaders/polylines.wgsl
@@ -1,0 +1,67 @@
+struct UBO {
+  cone_back_scale: f32,
+  viewport_ratio: f32,
+  look_distance: f32,
+  scale: f32,
+  forward: vec3f,
+  // direction up overhead, better unit vector
+  upward: vec3f,
+  rightward: vec3f,
+  camera_position: vec3f,
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms: UBO;
+
+{{perspective}}
+
+{{colors}}
+
+// main
+
+struct VertexOut {
+  @builtin(position) position: vec4f,
+  @location(0) original: vec3f,
+  @location(1) color: vec3f,
+};
+
+@vertex
+fn vertex_main(
+  @location(0) position: vec3f,
+  @location(1) brush: u32,
+  @location(2) direction: vec3f,
+  @location(3) width: f32,
+) -> VertexOut {
+  var output: VertexOut;
+
+  var p1 = position;
+
+  var next = cross(direction, uniforms.forward);
+  if (length(next) < 0.0001) {
+    // if parallel, use leftward
+    next = -next;
+  }
+  let brush_direction = normalize(next);
+  if (brush == 1) {
+    p1 += brush_direction * width * 0.5;
+  } else {
+    p1 -= brush_direction * width * 0.5;
+  }
+
+  let p = transform_perspective(p1.xyz).point_position;
+  let scale: f32 = 0.002;
+  output.position = vec4(p[0]*scale, p[1]*scale, p[2]*scale, 1.0);
+  output.original = position;
+  output.color = hsl(0.14, 1.0, 0.2);
+
+  return output;
+}
+
+const middle: f32 = 50.0;
+const limit: f32 = 48.0;
+
+@fragment
+fn fragment_main(vtx_out: VertexOut) -> @location(0) vec4f {
+  // return vec4f(vtx_out.color, 1.0);
+  return vec4(0.7, 0.7, 0.7, 1);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.7.0.tgz#09a66c814c849beb9403e1f63ec24fbd655c1430"
-  integrity sha512-Q+K1cWxm/F58jEOYVNy7HbMFqtiF0+tdUsamLJrNaUUU5/gNymfI9WvgiWYBp7/KiWm8gsPximu9zIkcrW4pwQ==
+"@calcit/procs@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.7.2.tgz#4121b737c1a48682f6c1aaf8b45226bbe7d217ea"
+  integrity sha512-hfTSX4N/pYQW9GNf8aWDp95TByTujk49wJcPGbUivxEa+K2WlJ0jefbhe0N2Xv8wVd6k5AlYljneGDIs61fRnA==
   dependencies:
     "@calcit/ternary-tree" "0.0.19"
     "@cirru/parser.ts" "^0.0.6"
@@ -150,10 +150,10 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@triadica/lagopus@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@triadica/lagopus/-/lagopus-0.0.14.tgz#63063966c43df67c5b905938cce7bdcc51bb9af4"
-  integrity sha512-35koHJwn8fmUzHNbQ/COKQ3kk4qH6iH1SM2IzUyIfR1PXq1oPWE/NROraAfPc31VjoVd2agjcCxv4Wmfy6iHBg==
+"@triadica/lagopus@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@triadica/lagopus/-/lagopus-0.0.15.tgz#268590542b72ba8e248665c8e77d1fcd257ed71e"
+  integrity sha512-9u7jcBZ1m3PnYqwb73n6Drm31K0UMvMO0dGj4UjE4Vu67WuHrspMTW0ctCaJalf8zPSwkKNNqoCmV+ndXrfb6A==
   dependencies:
     "@triadica/touch-control" "^0.0.3"
     ismobilejs "^1.1.1"
@@ -335,9 +335,9 @@ query-string@^8.1.0:
     split-on-first "^3.0.0"
 
 rollup@^3.21.0:
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.25.0.tgz#71327d396a9decbf23c87b55916ae7204211738a"
-  integrity sha512-FnJkNRst2jEZGw7f+v4hFo6UTzpDKrAKcHZWcEfm5/GJQ5CK7wgb4moNLNAe7npKUev7yQn1AY/YbZRIxOv6Qg==
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.25.1.tgz#9fff79d22ff1a904b2b595a2fb9bc3793cb987d8"
+  integrity sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==
   optionalDependencies:
     fsevents "~2.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@calcit/procs@^0.7.2":
   version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.7.2.tgz#4121b737c1a48682f6c1aaf8b45226bbe7d217ea"
+  resolved "https://registry.npmjs.org/@calcit/procs/-/procs-0.7.2.tgz"
   integrity sha512-hfTSX4N/pYQW9GNf8aWDp95TByTujk49wJcPGbUivxEa+K2WlJ0jefbhe0N2Xv8wVd6k5AlYljneGDIs61fRnA==
   dependencies:
     "@calcit/ternary-tree" "0.0.19"
@@ -13,22 +13,22 @@
 
 "@calcit/std@^0.0.2":
   version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@calcit/std/-/std-0.0.2.tgz#8692ca6bd847b68b7365a75c5df124af82ab9192"
+  resolved "https://registry.npmjs.org/@calcit/std/-/std-0.0.2.tgz"
   integrity sha512-s976zyxZ2zk4BVKu9DXur0L5FC60AWSsrnu6Aw1YuaxjEpEakk02g/WOWwwRsYYKfgKeRcWvEFKkTWoSjrFH+w==
 
 "@calcit/ternary-tree@0.0.19":
   version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@calcit/ternary-tree/-/ternary-tree-0.0.19.tgz#b5b33a3d07a9e603feeef7cd642958c83628122f"
+  resolved "https://registry.npmjs.org/@calcit/ternary-tree/-/ternary-tree-0.0.19.tgz"
   integrity sha512-dn2kNlcOQOPtCAeE68MHcRgrZzRP+jNKBmDW2wO0S8HTUA2SeAbpzZoK0HfcTHFmlGl6yKpjZ95rICQ319AjcA==
 
 "@cirru/parser.ts@^0.0.6":
   version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@cirru/parser.ts/-/parser.ts-0.0.6.tgz#b95a84e02273fcbd71ff100925782b6f86410234"
+  resolved "https://registry.npmjs.org/@cirru/parser.ts/-/parser.ts-0.0.6.tgz"
   integrity sha512-qpDNPq+IuuwYjQFI+wzpd3ntbF7lwJs90v1XWyLQbL9Ru4ld4aHxVGwW/9F/QOu5mEGCMXtagCoYDf0HtOpDZg==
 
 "@cirru/writer.ts@^0.1.3":
   version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.3.tgz#5f54bdecaa20ba3dab16cbe6da711854138a9c0a"
+  resolved "https://registry.npmjs.org/@cirru/writer.ts/-/writer.ts-0.1.3.tgz"
   integrity sha512-vJnhmhm7we5UfQIwmZfQpF3bAFbVybzT6LbmkbQHxgijaQg3gPfNVsnSIa3g3KpmWVtvkzEx+nUy5aMwsJiV1A==
 
 "@esbuild/android-arm64@0.17.19":
@@ -48,7 +48,7 @@
 
 "@esbuild/darwin-arm64@0.17.19":
   version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz#584c34c5991b95d4d48d333300b1a4e2ff7be276"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz"
   integrity sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==
 
 "@esbuild/darwin-x64@0.17.19":
@@ -143,17 +143,17 @@
 
 "@rollup/pluginutils@^5.0.2":
   version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
+  resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz"
   integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==
   dependencies:
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@triadica/lagopus@^0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@triadica/lagopus/-/lagopus-0.0.15.tgz#268590542b72ba8e248665c8e77d1fcd257ed71e"
-  integrity sha512-9u7jcBZ1m3PnYqwb73n6Drm31K0UMvMO0dGj4UjE4Vu67WuHrspMTW0ctCaJalf8zPSwkKNNqoCmV+ndXrfb6A==
+"@triadica/lagopus@^0.0.16-a1":
+  version "0.0.16-a1"
+  resolved "https://registry.npmjs.org/@triadica/lagopus/-/lagopus-0.0.16-a1.tgz"
+  integrity sha512-0Gqstm4EE+X+8gaJeBX2uWa55kEuas0dNnNQ2USPHJn8fCW7GhuhZrzwwI9rfu72N5kA4Q05OV41deWNPXIKpA==
   dependencies:
     "@triadica/touch-control" "^0.0.3"
     ismobilejs "^1.1.1"
@@ -161,17 +161,17 @@
 
 "@triadica/touch-control@^0.0.3":
   version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@triadica/touch-control/-/touch-control-0.0.3.tgz#91e7ecb8fd2a36309180eada58f843b1dd44d876"
+  resolved "https://registry.npmjs.org/@triadica/touch-control/-/touch-control-0.0.3.tgz"
   integrity sha512-P6E+MJYmN6EJim0MjhK2kf99OjTZJwAXI7clJz6DDsaf/HCIbyYnVPWyMC7jgc6bPG2I5PAnLga5gHTR1lbUzA==
 
 "@types/estree@^1.0.0":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz"
   integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
 
 bottom-tip@^0.1.5:
   version "0.1.5"
-  resolved "https://registry.yarnpkg.com/bottom-tip/-/bottom-tip-0.1.5.tgz#ca81e738fba6ae956a5b4c55a78a127820c9b99e"
+  resolved "https://registry.npmjs.org/bottom-tip/-/bottom-tip-0.1.5.tgz"
   integrity sha512-53RCkWg6hY8M7Y9lPgU2f2bAEejQh0H6SCL9B8ufFdYAOAH/cUEwxSsBIH0AcPbOcNaSgdEJr9OhdnTUENe5bA==
   dependencies:
     nanoid "^4.0.1"
@@ -179,27 +179,27 @@ bottom-tip@^0.1.5:
 
 browser-split@0.0.1:
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/browser-split/-/browser-split-0.0.1.tgz#7b097574f8e3ead606fb4664e64adfdda2981a93"
+  resolved "https://registry.npmjs.org/browser-split/-/browser-split-0.0.1.tgz"
   integrity sha512-JhvgRb2ihQhsljNda3BI8/UcRHVzrVwo3Q+P8vDtSiyobXuFpuZ9mq+MbRGMnC22CjW3RrfXdg6j6ITX8M+7Ow==
 
 camelize@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
+  resolved "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz"
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 decode-uri-component@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz#2ac4859663c704be22bf7db760a1494a49ab2cc5"
+  resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz"
   integrity sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==
 
 dom-walk@^0.1.0:
   version "0.1.2"
-  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
+  resolved "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz"
   integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
 
 error@^4.3.0:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/error/-/error-4.4.0.tgz#bf69ff251fb4a279c19adccdaa6b61e90d9bf12a"
+  resolved "https://registry.npmjs.org/error/-/error-4.4.0.tgz"
   integrity sha512-SNDKualLUtT4StGFP7xNfuFybL2f6iJujFtrWuvJqGbVQGaN+adE23veqzPz1hjUjTunLi2EnJ+0SJxtbJreKw==
   dependencies:
     camelize "^1.0.0"
@@ -208,7 +208,7 @@ error@^4.3.0:
 
 esbuild@^0.17.5:
   version "0.17.19"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.19.tgz#087a727e98299f0462a3d0bcdd9cd7ff100bd955"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz"
   integrity sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==
   optionalDependencies:
     "@esbuild/android-arm" "0.17.19"
@@ -236,29 +236,29 @@ esbuild@^0.17.5:
 
 estree-walker@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 ev-store@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/ev-store/-/ev-store-7.0.0.tgz#1ab0c7f82136505dd74b31d17701cb2be6d26558"
+  resolved "https://registry.npmjs.org/ev-store/-/ev-store-7.0.0.tgz"
   integrity sha512-otazchNRnGzp2YarBJ+GXKVGvhxVATB1zmaStxJBYet0Dyq7A9VhH8IUEB/gRcL6Ch52lfpgPTRJ2m49epyMsQ==
   dependencies:
     individual "^3.0.0"
 
 filter-obj@^5.1.0:
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-5.1.0.tgz#5bd89676000a713d7db2e197f660274428e524ed"
+  resolved "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz"
   integrity sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==
 
 fsevents@~2.3.2:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 global@^4.3.0:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
+  resolved "https://registry.npmjs.org/global/-/global-4.4.0.tgz"
   integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
   dependencies:
     min-document "^2.19.0"
@@ -266,54 +266,54 @@ global@^4.3.0:
 
 individual@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/individual/-/individual-3.0.0.tgz#e7ca4f85f8957b018734f285750dc22ec2f9862d"
+  resolved "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz"
   integrity sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==
 
 is-object@^1.0.1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
+  resolved "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz"
   integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
 
 ismobilejs@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ismobilejs/-/ismobilejs-1.1.1.tgz#c56ca0ae8e52b24ca0f22ba5ef3215a2ddbbaa0e"
+  resolved "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz"
   integrity sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==
 
 min-document@^2.19.0:
   version "2.19.0"
-  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  resolved "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz"
   integrity sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==
   dependencies:
     dom-walk "^0.1.0"
 
 nanoid@^3.3.6:
   version "3.3.6"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
 nanoid@^4.0.1:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.2.tgz#140b3c5003959adbebf521c170f282c5e7f9fb9e"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz"
   integrity sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==
 
 next-tick@^0.2.2:
   version "0.2.2"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-0.2.2.tgz#75da4a927ee5887e39065880065b7336413b310d"
+  resolved "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
   integrity sha512-f7h4svPtl+QidoBv4taKXUjJ70G2asaZ8G28nS0OkqaalX8dwwrtWtyxEDPK62AC00ur/+/E0pUwBwY5EPn15Q==
 
 picocolors@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.3.1:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 postcss@^8.4.23:
   version "8.4.24"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz"
   integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
   dependencies:
     nanoid "^3.3.6"
@@ -322,12 +322,12 @@ postcss@^8.4.23:
 
 process@^0.11.10:
   version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
 query-string@^8.1.0:
   version "8.1.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-8.1.0.tgz#e7f95367737219544cd360a11a4f4ca03836e115"
+  resolved "https://registry.npmjs.org/query-string/-/query-string-8.1.0.tgz"
   integrity sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==
   dependencies:
     decode-uri-component "^0.4.1"
@@ -336,29 +336,29 @@ query-string@^8.1.0:
 
 rollup@^3.21.0:
   version "3.25.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.25.1.tgz#9fff79d22ff1a904b2b595a2fb9bc3793cb987d8"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-3.25.1.tgz"
   integrity sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==
   optionalDependencies:
     fsevents "~2.3.2"
 
 source-map-js@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 split-on-first@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-3.0.0.tgz#f04959c9ea8101b9b0bbf35a61b9ebea784a23e7"
+  resolved "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz"
   integrity sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==
 
 string-template@~0.2.0:
   version "0.2.1"
-  resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
+  resolved "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
 virtual-dom@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/virtual-dom/-/virtual-dom-2.1.1.tgz#80eda2d481b9ede0c049118cefcb4a05f21d1375"
+  resolved "https://registry.npmjs.org/virtual-dom/-/virtual-dom-2.1.1.tgz"
   integrity sha512-wb6Qc9Lbqug0kRqo/iuApfBpJJAq14Sk1faAnSmtqXiwahg7PVTvWMs9L02Z8nNIMqbwsxzBAA90bbtRLbw0zg==
   dependencies:
     browser-split "0.0.1"
@@ -372,14 +372,14 @@ virtual-dom@^2.1.1:
 
 vite-plugin-glsl@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vite-plugin-glsl/-/vite-plugin-glsl-1.1.2.tgz#7f1750bb90f4e70b3459039e1b1d201bb099d519"
+  resolved "https://registry.npmjs.org/vite-plugin-glsl/-/vite-plugin-glsl-1.1.2.tgz"
   integrity sha512-zmXsfc1vn2MlYve9t3FAoWuhLyoCkNS1TuQL+TkXZL7tGmBjRErp10eNYxcse5tK9oUC5MyJpNc4ElpQnx8DoA==
   dependencies:
     "@rollup/pluginutils" "^5.0.2"
 
 vite@^4.3.9:
   version "4.3.9"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.3.9.tgz#db896200c0b1aa13b37cdc35c9e99ee2fdd5f96d"
+  resolved "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz"
   integrity sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==
   dependencies:
     esbuild "^0.17.5"
@@ -390,15 +390,15 @@ vite@^4.3.9:
 
 x-is-array@0.1.0:
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/x-is-array/-/x-is-array-0.1.0.tgz#de520171d47b3f416f5587d629b89d26b12dc29d"
+  resolved "https://registry.npmjs.org/x-is-array/-/x-is-array-0.1.0.tgz"
   integrity sha512-goHPif61oNrr0jJgsXRfc8oqtYzvfiMJpTqwE7Z4y9uH+T3UozkGqQ4d2nX9mB9khvA8U2o/UbPOFjgC7hLWIA==
 
 x-is-string@0.1.0:
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  resolved "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz"
   integrity sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w==
 
 xtend@~4.0.0:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
introduced a better way of defining polylines. it does not require `flatten` before passing to component, which could be slow in Calcit.
